### PR TITLE
RE SkyrimVM.h update events

### DIFF
--- a/include/RE/S/SkyrimVM.h
+++ b/include/RE/S/SkyrimVM.h
@@ -139,6 +139,24 @@ namespace RE
 	public:
 		inline static constexpr auto RTTI = RTTI_SkyrimVM;
 
+		struct UnkUpdateDataEvent
+		{
+		public:
+			enum class UpdateType : bool
+			{
+				kRepeat = 0,					// RegisterForUpdate/RegisterForUpdateGameTime
+				kNoRepeat = 1,					// RegisterForSingleUpdate/RegisterForSingleUpdateGameTime
+			};
+			// members
+			std::uint32_t unk00;				// 00 - Possibly BSIntrusiveRefCounted?
+			UpdateType    updateType;           // 04
+			std::uint16_t pad_06;               // 06
+			std::uint32_t timeToSendEvent;		// 08 - updateTime + currentVMMenuMode/currentVMDaysPassed 
+			std::uint32_t updateTime;			// 0C
+			VMHandle      handle;				// 10
+		};
+		static_assert(sizeof(UnkUpdateDataEvent) == 0x18);
+
 		~SkyrimVM() override;  // 00
 
 		static SkyrimVM* GetSingleton();
@@ -164,17 +182,19 @@ namespace RE
 		std::uint32_t                                                         currentVMTime;              // 068C
 		std::uint32_t                                                         currentVMMenuModeTime;      // 0690
 		std::uint32_t                                                         currentVMGameTime;          // 0694
-		std::uint64_t                                                         unk0698;                    // 0698
-		std::uint64_t                                                         unk06A0;                    // 06A0
+		std::uint32_t                                                         currentVMDaysPassed;        // 0698 - Calender.GetDaysPassed() * 1000
+		mutable BSSpinLock                                                    unk069C;                    // 0698
+		std::uint32_t                                                         unk06A4;                    // 06A0
 		BSTArray<void*>                                                       unk06A8;                    // 06A8
 		BSTArray<void*>                                                       unk06C0;                    // 06C0
 		BSTArray<void*>                                                       unk06D8;                    // 06D8
 		std::uint64_t                                                         unk06F0;                    // 06F0
 		BSTArray<void*>                                                       unk06F8;                    // 06F8
-		std::uint64_t                                                         unk0710;                    // 0710
-		std::uint64_t                                                         unk0718;                    // 0718
-		BSTArray<void*>                                                       unk0720;                    // 0720
-		BSTArray<void*>                                                       unk0738;                    // 0738
+		std::uint32_t                                                         unk0710;                    // 0710
+		mutable BSSpinLock                                                    queuedOnUpdateEventLock;    // 0714
+		std::uint32_t                                                         pad071C;                    // 071C
+		BSTArray<UnkUpdateDataEvent*>                                         queuedOnUpdateEvents;		  // 0720
+		BSTArray<UnkUpdateDataEvent*>                                         queuedOnUpdateGameEvents;   // 0738
 		std::uint64_t                                                         unk0750;                    // 0750
 		std::uint64_t                                                         unk0758;                    // 0758
 		BSTHashMap<UnkKey, UnkValue>                                          unk0760;                    // 0760

--- a/include/RE/S/SkyrimVM.h
+++ b/include/RE/S/SkyrimVM.h
@@ -139,7 +139,7 @@ namespace RE
 	public:
 		inline static constexpr auto RTTI = RTTI_SkyrimVM;
 
-		struct UnkUpdateDataEvent
+		struct UpdateDataEvent
 		{
 		public:
 			enum class UpdateType : bool
@@ -150,12 +150,12 @@ namespace RE
 			// members
 			std::uint32_t unk00;				// 00 - Possibly BSIntrusiveRefCounted?
 			UpdateType    updateType;           // 04
-			std::uint16_t pad_06;               // 06
+			std::uint16_t pad06;				// 06
 			std::uint32_t timeToSendEvent;		// 08 - updateTime + currentVMMenuMode/currentVMDaysPassed 
 			std::uint32_t updateTime;			// 0C
 			VMHandle      handle;				// 10
 		};
-		static_assert(sizeof(UnkUpdateDataEvent) == 0x18);
+		static_assert(sizeof(UpdateDataEvent) == 0x18);
 
 		~SkyrimVM() override;  // 00
 
@@ -193,8 +193,8 @@ namespace RE
 		std::uint32_t                                                         unk0710;                      // 0710
 		mutable BSSpinLock                                                    queuedOnUpdateEventLock;		// 0714
 		std::uint32_t                                                         pad071C;						// 071C
-		BSTArray<UnkUpdateDataEvent*>                                         queuedOnUpdateEvents;			// 0720
-		BSTArray<UnkUpdateDataEvent*>                                         queuedOnUpdateGameEvents;		// 0738
+		BSTArray<UpdateDataEvent*>										      queuedOnUpdateEvents;			// 0720
+		BSTArray<UpdateDataEvent*>                                            queuedOnUpdateGameEvents;		// 0738
 		std::uint64_t                                                         unk0750;                      // 0750
 		std::uint64_t                                                         unk0758;                      // 0758
 		BSTHashMap<UnkKey, UnkValue>                                          unk0760;                      // 0760


### PR DESCRIPTION
`currentVMDaysPassed` is used for checking when to send update events for `queuedOnUpdateGameEvents`.

`currentVMMenuModeTime` is used to check when to send update events for `queuedOnUpdateEvents`

`updateTime` variable is calculated as follows:
RegisterFor(Single)Update -> (time argument in papyrus) * 1000, minimum 33 milliseconds
RegisterFor(Single)UpdateGameTime -> (time argument in papyrus) * 0.041666668 * 1000, minimum 6.9
