### PR TITLE
Corrected position of MapMarkerData::type and renamed kDontUseMapData…

### DIFF
--- a/include/RE/E/ExtraMapMarker.h
+++ b/include/RE/E/ExtraMapMarker.h
@@ -91,9 +91,10 @@ namespace RE
 		// members
 		TESFullName                                 locationName;  // 00
 		stl::enumeration<Flag, std::uint8_t>        flags;         // 10
-		stl::enumeration<MARKER_TYPE, std::uint8_t> type;          // 11
-		std::uint16_t                               pad02;         // 12
-		std::uint32_t                               pad04;         // 14
+		std::uint8_t                                pad11;         // 11
+		stl::enumeration<MARKER_TYPE, std::uint8_t> type;          // 12
+		std::uint8_t                                pad13;         // 13
+		std::uint32_t                               pad14;         // 14
 	};
 	static_assert(sizeof(MapMarkerData) == 0x18);
 

--- a/include/RE/T/TESWorldSpace.h
+++ b/include/RE/T/TESWorldSpace.h
@@ -138,7 +138,7 @@ namespace RE
 			kNone = 0,
 			kUseLandData = 1 << 0,
 			kUseLODData = 1 << 1,
-			kDontUseMapData = 1 << 2,
+			kUseMapData = 1 << 2,
 			kUseWaterData = 1 << 3,
 			kUseClimateData = 1 << 4,
 			kUseImageSpaceData = 1 << 5,  // unused


### PR DESCRIPTION
MapMarkerData::type is at offset 12, not 11. This was originally corrected by Exit-9B, the author of comap here: https://github.com/Ryan-rsm-McKenzie/CommonLibSSE/blob/acecb91b22ae541501d845f55768a62729a20577/include/RE/E/ExtraMapMarker.h

As for ParentUseFlag::kDontUseMapData->kUseMapData, this flag is exactly the same that the "Use Map Data" in xEdit. No reverse logic there. When in doubt, check function ID(SE=20050, AE=20493), that function returns a ptr to the WORLD_MAP_DATA that the MapMenu will be using, and makes use of this flag.