### PR TITLE
RE SkyrimVM::RelayEvent

### DIFF
--- a/include/RE/Offsets.h
+++ b/include/RE/Offsets.h
@@ -402,6 +402,7 @@ namespace RE
 		namespace SkyrimVM
 		{
 			inline constexpr REL::ID QueuePostRenderCall(static_cast<std::uint64_t>(53955));
+			inline constexpr REL::ID RelayEvent(static_cast<std::uint64_t>(54033));
 			inline constexpr REL::ID Singleton(static_cast<std::uint64_t>(400475));
 		}
 
@@ -895,6 +896,7 @@ namespace RE
 		namespace SkyrimVM
 		{
 			inline constexpr REL::ID QueuePostRenderCall(static_cast<std::uint64_t>(53144));
+			inline constexpr REL::ID RelayEvent(static_cast<std::uint64_t>(53221));
 			inline constexpr REL::ID Singleton(static_cast<std::uint64_t>(514315));
 		}
 

--- a/include/RE/S/SkyrimVM.h
+++ b/include/RE/S/SkyrimVM.h
@@ -24,6 +24,7 @@ namespace RE
 {
 	namespace BSScript
 	{
+		class IFunctionArguments;
 		class IVirtualMachine;
 		class IVMDebugInterface;
 		class IVMSaveLoadInterface;
@@ -193,11 +194,18 @@ namespace RE
 		};
 		static_assert(sizeof(LOSDataEvent) == 0x20);
 
+		struct ISendEventFilter
+		{
+			virtual bool matchesFilter(VMHandle handle) = 0;
+		};
+
 		~SkyrimVM() override;  // 00
 
 		static SkyrimVM* GetSingleton();
 
 		bool QueuePostRenderCall(const BSTSmartPointer<SkyrimScript::DelayFunctor>& a_functor);
+		void RelayEvent(VMHandle handle, BSFixedString* event, BSScript::IFunctionArguments* args, ISendEventFilter* optionalFilter);
+		void SendAndRelayEvent(VMHandle handle, BSFixedString* event, BSScript::IFunctionArguments* args, ISendEventFilter* optionalFilter);
 
 		// members
 		BSTSmartPointer<BSScript::IVirtualMachine>                            impl;                         // 0200

--- a/src/RE/S/SkyrimVM.cpp
+++ b/src/RE/S/SkyrimVM.cpp
@@ -1,4 +1,5 @@
 #include "RE/S/SkyrimVM.h"
+#include "RE/V/VirtualMachine.h"
 
 namespace RE
 {
@@ -13,5 +14,20 @@ namespace RE
 		using func_t = decltype(&SkyrimVM::QueuePostRenderCall);
 		REL::Relocation<func_t> func{ Offset::SkyrimVM::QueuePostRenderCall };
 		return func(this, a_functor);
+	}
+
+	void SkyrimVM::RelayEvent(VMHandle a_handle, BSFixedString* a_event, BSScript::IFunctionArguments* a_args, SkyrimVM::ISendEventFilter* a_optionalFilter)
+	{
+		using func_t = decltype(&SkyrimVM::RelayEvent);
+		REL::Relocation<func_t> func{ Offset::SkyrimVM::RelayEvent };
+		return func(this, a_handle, a_event, a_args, a_optionalFilter);
+	}
+
+	// a_handle must be a handle for TESObjectREFR
+	// Sends event to handle directly, then relays event to all reference aliases and magic effects attached to reference
+	void SkyrimVM::SendAndRelayEvent(VMHandle a_handle, BSFixedString* a_event, BSScript::IFunctionArguments* a_args, SkyrimVM::ISendEventFilter* a_optionalFilter)
+	{
+		impl.get()->SendEvent(a_handle, *a_event, a_args);
+		RelayEvent(a_handle, a_event, a_args, a_optionalFilter);
 	}
 }


### PR DESCRIPTION
RelayEvent relays events to all active magic effects and reference aliases in for a `TESObjectREFR` handle, ~~untested on AE.~~