### PR TITLE
Added IsAttacking and GetWarmthRating to Actor

### DIFF
--- a/include/RE/A/Actor.h
+++ b/include/RE/A/Actor.h
@@ -522,7 +522,7 @@ namespace RE
 		[[nodiscard]] SOUL_LEVEL     GetSoulSize() const;
 		TESFaction*                  GetVendorFaction();
 		const TESFaction*            GetVendorFaction() const;
-		float						 GetWarmthRating() const;
+		float                        GetWarmthRating() const;
 		[[nodiscard]] TESObjectARMO* GetWornArmor(BGSBipedObjectForm::BipedObjectSlot a_slot);
 		[[nodiscard]] TESObjectARMO* GetWornArmor(FormID a_formID);
 		bool                         HasKeywordString(std::string_view a_formEditorID);
@@ -530,7 +530,7 @@ namespace RE
 		bool                         HasPerk(BGSPerk* a_perk) const;
 		bool                         HasSpell(SpellItem* a_spell) const;
 		void                         InterruptCast(bool a_restoreMagicka) const;
-		bool						 IsAttacking() const;
+		bool                         IsAttacking() const;
 		bool                         IsAIEnabled() const;
 		bool                         IsAlarmed() const;
 		bool                         IsAMount() const;

--- a/include/RE/A/Actor.h
+++ b/include/RE/A/Actor.h
@@ -522,6 +522,7 @@ namespace RE
 		[[nodiscard]] SOUL_LEVEL     GetSoulSize() const;
 		TESFaction*                  GetVendorFaction();
 		const TESFaction*            GetVendorFaction() const;
+		float						 GetWarmthRating() const;
 		[[nodiscard]] TESObjectARMO* GetWornArmor(BGSBipedObjectForm::BipedObjectSlot a_slot);
 		[[nodiscard]] TESObjectARMO* GetWornArmor(FormID a_formID);
 		bool                         HasKeywordString(std::string_view a_formEditorID);
@@ -529,6 +530,7 @@ namespace RE
 		bool                         HasPerk(BGSPerk* a_perk) const;
 		bool                         HasSpell(SpellItem* a_spell) const;
 		void                         InterruptCast(bool a_restoreMagicka) const;
+		bool						 IsAttacking() const;
 		bool                         IsAIEnabled() const;
 		bool                         IsAlarmed() const;
 		bool                         IsAMount() const;

--- a/src/RE/A/Actor.cpp
+++ b/src/RE/A/Actor.cpp
@@ -473,6 +473,13 @@ namespace RE
 		return vendorFaction;
 	}
 
+	float Actor::GetWarmthRating() const
+	{
+		using func_t = decltype(&Actor::GetWarmthRating);
+		REL::Relocation<func_t> func{ RELOCATION_ID(25834, 26394) };
+		return func(this);
+	}
+
 	TESObjectARMO* Actor::GetWornArmor(BGSBipedObjectForm::BipedObjectSlot a_slot)
 	{
 		const auto inv = GetInventory([](TESBoundObject& a_object) {
@@ -540,6 +547,13 @@ namespace RE
 		using func_t = decltype(&Actor::InterruptCast);
 		REL::Relocation<func_t> func{ RELOCATION_ID(37808, 38757) };
 		return func(this, a_restoreMagicka);
+	}
+
+	bool Actor::IsAttacking() const
+	{
+		using func_t = decltype(&Actor::IsAttacking);
+		REL::Relocation<func_t> func{ RELOCATION_ID(37637, 38590) };
+		return func(this);
 	}
 
 	bool Actor::IsAIEnabled() const


### PR DESCRIPTION
Apparently a player's warmth can also be accessed by checking the "Variable09" actor value.
However, I feel like calling the engine level function is a little more clear 