### PR TITLE
RE CallType, StackType. Confirm missing VTABLEs

### DIFF
--- a/include/RE/I/IFuncCallQuery.h
+++ b/include/RE/I/IFuncCallQuery.h
@@ -21,6 +21,10 @@ namespace RE
 
 				enum class CallType
 				{
+					kMember,
+					kStatic,
+					kGetter,
+					kSetter
 				};
 
 				virtual ~IFuncCallQuery();  // 00

--- a/include/RE/N/NativeFunctionBase.h
+++ b/include/RE/N/NativeFunctionBase.h
@@ -23,6 +23,7 @@ namespace RE
 			{
 			public:
 				inline static constexpr auto RTTI = RTTI_BSScript__NF_util__NativeFunctionBase;
+				inline static constexpr auto VTABLE = VTABLE_BSScript__NF_util__NativeFunctionBase;
 
 				NativeFunctionBase() = delete;
 				explicit NativeFunctionBase(std::string_view a_fnName, std::string_view a_className, bool a_isStatic, std::uint16_t a_numParams);

--- a/include/RE/S/Stack.h
+++ b/include/RE/S/Stack.h
@@ -46,6 +46,9 @@ namespace RE
 
 			enum class StackType
 			{
+				kNormal,
+				kPropertyInitialize,
+				kInitialize
 			};
 
 			struct MemoryPageData

--- a/include/RE/V/VirtualMachine.h
+++ b/include/RE/V/VirtualMachine.h
@@ -46,6 +46,7 @@ namespace RE
 			{
 			public:
 				inline static constexpr auto RTTI = RTTI_BSScript__Internal__VirtualMachine;
+				inline static constexpr auto VTABLE = VTABLE_BSScript__Internal__VirtualMachine;
 
 				struct QueuedUnbindRefs
 				{


### PR DESCRIPTION
CallType, StackType are confirmed by the associated strings used for printing error information

Missing VTABLEs confirmed when testing VFunc hooking in SE.