### PR TITLE
RE MemoryPagePolicy

### DIFF
--- a/include/RE/I/IMemoryPagePolicy.h
+++ b/include/RE/I/IMemoryPagePolicy.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include "RE/M/MemoryPage.h"
 namespace RE
 {
 	namespace BSScript
@@ -9,13 +9,26 @@ namespace RE
 		public:
 			inline static constexpr auto RTTI = RTTI_BSScript__IMemoryPagePolicy;
 
+			enum class AllocationStatus
+			{
+				kSuccess,
+				kFailed,
+				kOutOfMemory
+			};
+
+			enum class NewPageStrategy
+			{
+				kNormal,
+				kIgnoreMemoryLimit
+			};
+
 			virtual ~IMemoryPagePolicy();  // 00
 
 			// add
-			virtual void Unk_01(void) = 0;  // 01
-			virtual void Unk_02(void) = 0;  // 02
-			virtual void Unk_03(void) = 0;  // 03
-			virtual void Unk_04(void) = 0;  // 04
+			virtual std::uint32_t    MaximumPageSize() = 0;                                                                                         // 01
+			virtual AllocationStatus AllocatePage(std::uint32_t a_pageSize, NewPageStrategy a_stategy, BSTAutoPointer<MemoryPage>& a_newPage) = 0;  // 02
+			virtual AllocationStatus GetLargestAvailablePage(BSTAutoPointer<MemoryPage>& a_newPage) = 0;                                            // 03
+			virtual void             DisposePage(BSTAutoPointer<MemoryPage>& a_oldPage) = 0;                                                        // 04
 		};
 		static_assert(sizeof(IMemoryPagePolicy) == 0x8);
 	}

--- a/include/RE/S/SimpleAllocMemoryPagePolicy.h
+++ b/include/RE/S/SimpleAllocMemoryPagePolicy.h
@@ -15,16 +15,16 @@ namespace RE
 			~SimpleAllocMemoryPagePolicy() override;  // 00
 
 			// override (IMemoryPagePolicy)
-			void Unk_01(void) override;  // 01 - { return maxPageSize; }
-			void Unk_02(void) override;  // 02
-			void Unk_03(void) override;  // 03
-			void Unk_04(void) override;  // 04
+			std::uint32_t    MaximumPageSize() override;                                                                                         // 01 - { return maxPageSize; }
+			AllocationStatus AllocatePage(std::uint32_t a_pageSize, NewPageStrategy a_stategy, BSTAutoPointer<MemoryPage>& a_newPage) override;  // 02
+			AllocationStatus GetLargestAvailablePage(BSTAutoPointer<MemoryPage>& a_newPage) override;                                            // 03
+			void             DisposePage(BSTAutoPointer<MemoryPage>& a_newPage) override;                                                        // 04
 
 			// members
 			const std::uint32_t minPageSize{ 0 };          // 08
 			const std::uint32_t maxPageSize{ 0 };          // 0C
 			const std::uint32_t maxAllocatedMemory{ 0 };   // 10
-			const std::uint32_t maxStackDepth{ 0 };        // 14
+			const bool          ignoreMemoryLimit{ 0 };    // 14 - Set each update by overstress status
 			BSSpinLock          dataLock;                  // 18
 			std::uint32_t       currentMemorySize;         // 20
 			std::uint32_t       maxAdditionalAllocations;  // 20


### PR DESCRIPTION
Names taken from FO4 CLIB

`maxStackDepth` corrected to `ignoreMemoryLimit` based on how it is used:
`141249998` (1.5.97)
```
  if ( a_strategy != kIgnoreMemoryLimit && !this->ignoreMemoryLimit )
  {
    vResult = kOutOfMemory;
    goto LABEL_15;
  }
```



See: https://github.com/Ryan-rsm-McKenzie/CommonLibF4/blob/master/CommonLibF4/include/RE/Bethesda/BSScript.h#L891