### PR TITLE
Fix `GetDurationOfApplicationRunTime` return type

### DIFF
--- a/include/RE/M/Misc.h
+++ b/include/RE/M/Misc.h
@@ -13,16 +13,16 @@ namespace RE
 	class TESForm;
 	class InventoryEntryData;
 
-	void     CreateMessage(const char* a_message, IMessageBoxCallback* a_callback, std::uint32_t a_arg3, std::uint32_t a_arg4, std::uint32_t a_arg5, const char* a_buttonText, const char* a_secondaryButtonText);
-	void     CreateRefHandle(RefHandle& a_handleOut, TESObjectREFR* a_refTo);
-	void     DebugNotification(const char* a_notification, const char* a_soundToPlay = 0, bool a_cancelIfAlreadyQueued = true);
-	void     DebugMessageBox(const char* a_message);
-	float    GetArmorFinalRating(InventoryEntryData* a_armorEntryData, float a_armorPerks, float a_skillMultiplier);
-	float    GetDurationOfApplicationRunTime();
-	Setting* GetINISetting(const char* a_name);
-	float    GetSecondsSinceLastFrame();
-	bool     LookupReferenceByHandle(const RefHandle& a_handle, NiPointer<Actor>& a_refrOut);
-	bool     LookupReferenceByHandle(const RefHandle& a_handle, NiPointer<TESObjectREFR>& a_refrOut);
-	void     PlaySound(const char* a_editorID);
-	void     ShakeCamera(float a_strength, const NiPoint3& a_position, float a_duration);
+	void          CreateMessage(const char* a_message, IMessageBoxCallback* a_callback, std::uint32_t a_arg3, std::uint32_t a_arg4, std::uint32_t a_arg5, const char* a_buttonText, const char* a_secondaryButtonText);
+	void          CreateRefHandle(RefHandle& a_handleOut, TESObjectREFR* a_refTo);
+	void          DebugNotification(const char* a_notification, const char* a_soundToPlay = 0, bool a_cancelIfAlreadyQueued = true);
+	void          DebugMessageBox(const char* a_message);
+	float         GetArmorFinalRating(InventoryEntryData* a_armorEntryData, float a_armorPerks, float a_skillMultiplier);
+	std::uint32_t GetDurationOfApplicationRunTime();
+	Setting*      GetINISetting(const char* a_name);
+	float         GetSecondsSinceLastFrame();
+	bool          LookupReferenceByHandle(const RefHandle& a_handle, NiPointer<Actor>& a_refrOut);
+	bool          LookupReferenceByHandle(const RefHandle& a_handle, NiPointer<TESObjectREFR>& a_refrOut);
+	void          PlaySound(const char* a_editorID);
+	void          ShakeCamera(float a_strength, const NiPoint3& a_position, float a_duration);
 }

--- a/src/RE/M/Misc.cpp
+++ b/src/RE/M/Misc.cpp
@@ -60,9 +60,9 @@ namespace RE
 		return func(a_armorEntryData, a_armorPerks, a_skillMultiplier);
 	}
 
-	float GetDurationOfApplicationRunTime()
+	std::uint32_t GetDurationOfApplicationRunTime()
 	{
-		REL::Relocation<float*> runtime{ RELOCATION_ID(523662, 410201) };
+		REL::Relocation<std::uint32_t*> runtime{ RELOCATION_ID(523662, 410201) };
 		return *runtime;
 	}
 


### PR DESCRIPTION
It seems to be returning some shitty values such as 3.15628e-40 while as `uint32_t` I get 225240 which seems to be milliseconds as int, what gives 3-4 minutes in game which seems accurate.