### PR TITLE
Added Actor Spell visitor

### DIFF
--- a/include/RE/A/Actor.h
+++ b/include/RE/A/Actor.h
@@ -250,6 +250,18 @@ namespace RE
 			};
 		};
 
+		struct ForEachSpellVisitor
+		{
+			enum class Result : uint32_t
+			{
+				kStop = 0,
+				kContinue = 1
+			};
+
+			virtual ~ForEachSpellVisitor(){};
+			virtual Result visit(RE::SpellItem* a) = 0;
+		};
+
 		~Actor() override;  // 000
 
 		// override (TESObjectREFR)
@@ -578,6 +590,7 @@ namespace RE
 		void                         UpdateWeaponAbility(TESForm* a_weapon, ExtraDataList* a_extraData, bool a_leftHand);
 		void                         VisitArmorAddon(TESObjectARMO* a_armor, TESObjectARMA* a_arma, std::function<void(bool a_firstPerson, NiAVObject& a_obj)> a_visitor);
 		bool                         VisitFactions(std::function<bool(TESFaction* a_faction, std::int8_t a_rank)> a_visitor);
+		void                         VisitSpells(ForEachSpellVisitor& a_visitor);
 		bool                         WouldBeStealing(const TESObjectREFR* a_target) const;
 
 		// members

--- a/src/RE/A/Actor.cpp
+++ b/src/RE/A/Actor.cpp
@@ -967,6 +967,13 @@ namespace RE
 		return false;
 	}
 
+	void Actor::VisitSpells(ForEachSpellVisitor& a_visitor)
+	{
+		using func_t = decltype(&Actor::VisitSpells);
+		REL::Relocation<func_t> func{ RELOCATION_ID(37827, 37827) };  // I do not know for AE
+		return func(this, a_visitor);
+	}
+
 	bool Actor::WouldBeStealing(const TESObjectREFR* a_target) const
 	{
 		return a_target != nullptr && !a_target->IsAnOwner(this, true, false);


### PR DESCRIPTION
There is useful function VisitSpells which is used for MagicMenu, HasSpell function and in other places.
It uses Actor__ForEachSpellVisitor class.
May be easily used for enumerating active (and discovered) spells.
