### PR TITLE
Added visitor functions

### DIFF
--- a/include/RE/A/ArmorRatingVisitorBase.h
+++ b/include/RE/A/ArmorRatingVisitorBase.h
@@ -12,7 +12,7 @@ namespace RE
 		virtual ~ArmorRatingVisitorBase();  // 00
 
 		// override (InventoryChanges::IItemChangeVisitor)
-		bool Visit(InventoryEntryData* a_entryData) override;  // 01
+		RE::BSContainer::ForEachResult Visit(InventoryEntryData* a_entryData) override;  // 01
 
 		// add
 		virtual bool HaveNotVisitedArmor(TESObjectARMO* a_armor);  // 04 - { return true; }

--- a/include/RE/I/InventoryChanges.h
+++ b/include/RE/I/InventoryChanges.h
@@ -23,9 +23,9 @@ namespace RE
 			virtual ~IItemChangeVisitor() = default;  // 00
 
 			// add
-			virtual BSContainer::ForEachResult Visit(InventoryEntryData* a_entryData) = 0;                                               // 01
+			virtual BSContainer::ForEachResult Visit(InventoryEntryData* a_entryData) = 0;                         // 01
 			virtual bool                       ShouldVisit(InventoryEntryData*, TESBoundObject*) { return true; }  // 02
-			virtual BSContainer::ForEachResult Unk_03(InventoryEntryData* a_entryData, void*, bool* a_arg3)								 // 03
+			virtual BSContainer::ForEachResult Unk_03(InventoryEntryData* a_entryData, void*, bool* a_arg3)        // 03
 			{
 				*a_arg3 = true;
 				return Visit(a_entryData);

--- a/include/RE/I/InventoryChanges.h
+++ b/include/RE/I/InventoryChanges.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "RE/B/BSContainer.h"
 #include "RE/B/BSTList.h"
 #include "RE/F/FormTypes.h"
 #include "RE/M/MemoryManager.h"
+#include "RE/T/TESBoundObject.h"
 
 namespace RE
 {
@@ -16,13 +18,18 @@ namespace RE
 		{
 		public:
 			inline static constexpr auto RTTI = RTTI_InventoryChanges__IItemChangeVisitor;
+			inline static constexpr auto VTABLE = VTABLE_InventoryChanges__IItemChangeVisitor;
 
-			virtual ~IItemChangeVisitor();  // 00
+			virtual ~IItemChangeVisitor() = default;  // 00
 
 			// add
-			virtual bool Visit(InventoryEntryData* a_entryData) = 0;  // 01
-			virtual void Unk_02(void);                                // 02 - { return 1; }
-			virtual void Unk_03(void);                                // 03
+			virtual BSContainer::ForEachResult Visit(InventoryEntryData* a_entryData) = 0;                                               // 01
+			virtual bool                       ShouldVisit(InventoryEntryData*, TESBoundObject*) { return true; }  // 02
+			virtual BSContainer::ForEachResult Unk_03(InventoryEntryData* a_entryData, void*, bool* a_arg3)								 // 03
+			{
+				*a_arg3 = true;
+				return Visit(a_entryData);
+			};
 		};
 		static_assert(sizeof(IItemChangeVisitor) == 0x8);
 
@@ -39,6 +46,8 @@ namespace RE
 		void           InitScripts();
 		void           SendContainerChangedEvent(ExtraDataList* a_itemExtraList, TESObjectREFR* a_fromRefr, TESForm* a_item, std::int32_t a_count);
 		void           SetUniqueID(ExtraDataList* a_itemList, TESForm* a_oldForm, TESForm* a_newForm);
+		void           VisitInventory(IItemChangeVisitor& visitor);
+		void           VisitWornItems(IItemChangeVisitor& visitor);
 
 		TES_HEAP_REDEFINE_NEW();
 

--- a/src/RE/A/ArmorRatingVisitorBase.cpp
+++ b/src/RE/A/ArmorRatingVisitorBase.cpp
@@ -2,7 +2,7 @@
 
 namespace RE
 {
-	bool ArmorRatingVisitorBase::Visit(InventoryEntryData* a_entryData)
+	RE::BSContainer::ForEachResult ArmorRatingVisitorBase::Visit(InventoryEntryData* a_entryData)
 	{
 		using func_t = decltype(&ArmorRatingVisitorBase::Visit);
 		REL::Relocation<func_t> func(RELOCATION_ID(39223, 40299));

--- a/src/RE/I/InventoryChanges.cpp
+++ b/src/RE/I/InventoryChanges.cpp
@@ -62,6 +62,20 @@ namespace RE
 		return func(this, a_itemList, a_oldForm, a_newForm);
 	}
 
+	void InventoryChanges::VisitInventory(IItemChangeVisitor& visitor)
+	{
+		using func_t = decltype(&InventoryChanges::VisitWornItems);
+		REL::Relocation<func_t> func{ RELOCATION_ID(15855, 15855) };  // I do not know for AE
+		return func(this, visitor);
+	}
+
+	void InventoryChanges::VisitWornItems(IItemChangeVisitor& visitor)
+	{
+		using func_t = decltype(&InventoryChanges::VisitWornItems);
+		REL::Relocation<func_t> func{ RELOCATION_ID(15856, 15856) };  // I do not know for AE
+		return func(this, visitor);
+	}
+
 	void InventoryChanges::InitFromContainerExtra()
 	{
 		using func_t = decltype(&InventoryChanges::InitFromContainerExtra);


### PR DESCRIPTION
There are two functions that iterates over inventory: one processes only equipped items, other processes all items.
Also there is another inventory enumeration function (1401E52E0), this is the only usage of second virtual function of InventoryChanges::IItemChangeVisitor. But it is not such useful.

Also I implemented two virtual functions of the class to make easier to use class (anyway, both are unused and also not pure).

Simple usage example.

```
void test_visitor() {
	class Visitor : public RE::InventoryChanges::IItemChangeVisitor
	{
		RE::BSContainer::ForEachResult Visit(RE::InventoryEntryData* entryData) override
		{
			logger::info("{}", entryData->GetDisplayName());
			return RE::BSContainer::ForEachResult::kContinue;
		}

	} visitor;

	auto player = RE::PlayerCharacter::GetSingleton();
	auto changes = player->GetInventoryChanges();
	changes->VisitWornItems(visitor);
}
```