### PR TITLE
RE UnlinkedTypes

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -1416,6 +1416,7 @@ set(SOURCES
 	include/RE/U/UIMessage.h
 	include/RE/U/UIMessageQueue.h
 	include/RE/U/UISaveLoadManager.h
+	include/RE/U/UnlinkedTypes.h
 	include/RE/U/UserEventEnabled.h
 	include/RE/U/UserEvents.h
 	include/RE/V/VATS.h
@@ -1725,6 +1726,7 @@ set(SOURCES
 	src/RE/U/UI.cpp
 	src/RE/U/UIBlurManager.cpp
 	src/RE/U/UIMessageQueue.cpp
+	src/RE/U/UnlinkedTypes.cpp
 	src/RE/U/UserEvents.cpp
 	src/RE/V/Variable.cpp
 	src/RE/V/VirtualMachine.cpp

--- a/include/RE/B/BSStorage.h
+++ b/include/RE/B/BSStorage.h
@@ -35,11 +35,11 @@ namespace RE
 		virtual BSStorageDefs::ErrorCode Write(std::size_t a_numBytes, const std::byte* a_bytes) = 0;               // 05
 
 		// members
-		bool          unk0C;  // 0C
-		bool          unk0D;  // 0D
-		uint16_t      unk0E;  // 0E
-		UnkData*      unk10;  // 10
-		std::uint64_t unk18;  // 18
+		bool          swapBytes;  // 0C
+		bool          unk0D;      // 0D
+		uint16_t      unk0E;      // 0E
+		UnkData*      unk10;      // 10
+		std::uint64_t unk18;      // 18
 	};
 	static_assert(sizeof(BSStorage) == 0x20);
 }

--- a/include/RE/C/CompiledScriptLoader.h
+++ b/include/RE/C/CompiledScriptLoader.h
@@ -2,6 +2,7 @@
 
 #include "RE/B/BSTSmartPointer.h"
 #include "RE/I/ILoader.h"
+#include "RE/I/IVMSaveLoadInterface.h"
 
 namespace RE
 {
@@ -14,6 +15,7 @@ namespace RE
 		{
 		public:
 			inline static constexpr auto RTTI = RTTI_BSScript__CompiledScriptLoader;
+			inline static constexpr auto VTABLE = VTABLE_BSScript__CompiledScriptLoader;
 
 			~CompiledScriptLoader() override;  // 00
 
@@ -23,12 +25,13 @@ namespace RE
 			bool     GetClass(const char* a_name, BSScript::UnlinkedTypes::Object& a_object) override;  // 03
 
 			// members
-			ErrorLogger*            errorHandler;  // 08
-			BSTSmartPointer<IStore> scriptStore;   // 10
-			std::uint64_t           unk18;         // 18
-			std::uint64_t           unk20;         // 20
-			std::uint64_t           unk28;         // 28
-			std::uint64_t           unk30;         // 30
+			ErrorLogger*            errorHandler;         // 08
+			BSTSmartPointer<IStore> scriptStore;          // 10
+			ReadableStringTable     readableStringTable;  // 18 - This gets filled and cleared each time reading from a script
+			std::byte               majorVersion;         // 30 - Set each time reading from a script
+			std::byte               minorVersion;         // 31 - Set each time reading from a script
+			std::byte               loadDebugInfo: 1;     // 32 - Set to INI setting `Papyrus::bLoadDebugInformation` in the constructor
+			std::byte               loadDocStrings: 1;    // 32 - Never set true in vanilla, requires loadDebugInfo = 1 to work
 		};
 		static_assert(sizeof(CompiledScriptLoader) == 0x38);
 	}

--- a/include/RE/I/ILoader.h
+++ b/include/RE/I/ILoader.h
@@ -1,16 +1,12 @@
 #pragma once
 
 #include "RE/B/BSTSmartPointer.h"
+#include "RE/U/UnlinkedTypes.h"
 
 namespace RE
 {
 	namespace BSScript
 	{
-		namespace UnlinkedTypes
-		{
-			class Object;
-		}
-
 		class IStore;
 
 		struct ILoader

--- a/include/RE/Skyrim.h
+++ b/include/RE/Skyrim.h
@@ -1413,6 +1413,7 @@
 #include "RE/U/UIMessage.h"
 #include "RE/U/UIMessageQueue.h"
 #include "RE/U/UISaveLoadManager.h"
+#include "RE/U/UnlinkedTypes.h"
 #include "RE/U/UserEventEnabled.h"
 #include "RE/U/UserEvents.h"
 #include "RE/V/VATS.h"

--- a/include/RE/U/UnlinkedTypes.h
+++ b/include/RE/U/UnlinkedTypes.h
@@ -1,0 +1,156 @@
+#pragma once
+
+#include "RE/B/BSFixedString.h"
+#include "RE/B/BSTArray.h"
+#include "RE/B/BSTHashMap.h"
+#include "RE/L/LinkerProcessor.h"
+#include "RE/T/TypeInfo.h"
+
+namespace RE
+{
+	namespace BSScript
+	{
+		namespace UnlinkedTypes
+		{
+			class ConvertTypeFunctor
+			{
+			public:
+				inline static constexpr auto RTTI = RTTI_BSScript__UnlinkedTypes__Function__ConvertTypeFunctor;
+				inline static constexpr auto VTABLE = VTABLE_BSScript__UnlinkedTypes__Function__ConvertTypeFunctor;
+
+				virtual ~ConvertTypeFunctor();  // 00
+
+				virtual bool ConvertVariableType(BSFixedString* a_typeAsString, TypeInfo& a_typeOut) = 0;  // 01
+			};
+			static_assert(sizeof(ConvertTypeFunctor) == 0x8);
+
+			class LinkerConvertTypeFunctor : public ConvertTypeFunctor
+			{
+			public:
+				~LinkerConvertTypeFunctor() override;  // 00
+
+				bool ConvertVariableType(BSFixedString* a_typeAsString, TypeInfo& a_typeOut) override;  // 01 - This just jumps to LinkerProcessor::ConvertVariableType
+
+				// members
+				LinkerProcessor* linker;  // 08
+			};
+			static_assert(sizeof(LinkerConvertTypeFunctor) == 0x10);
+
+			class Function
+			{
+			public:
+				struct InstructionStream
+				{
+				public:
+					// members
+					std::uint64_t unk00;  // 00
+					std::uint32_t unk08;  // 08
+					std::uint32_t unk0C;  // 0C
+					std::uint32_t pad10;  // 10
+					std::uint32_t unk14;  // 14
+					std::uint64_t unk18;  // 18
+					std::uint64_t unk20;  // 20
+					std::uint64_t unk28;  // 28
+					std::uint64_t unk30;  // 30
+					std::uint64_t unk38;  // 38
+					std::uint64_t unk40;  // 40
+				};
+				static_assert(sizeof(InstructionStream) == 0x48);
+
+				// members
+				BSFixedString               returnTypeName;      // 00
+				BSFixedString               docString;           // 08
+				bool                        isNative;            // 10
+				bool                        isGlobal;            // 11
+				std::uint16_t               pad12;               // 12
+				std::uint32_t               isPropertyFunction;  // 14
+				std::uint32_t               userFlags;           // 18
+				BSScrapArray<BSFixedString> paramNameArray;      // 20 - index i holds the name of the parameter
+				BSScrapArray<BSFixedString> paramTypeArray;      // 40 - index i holds the type of said parameter from above
+				BSScrapArray<BSFixedString> localNameArray;      // 60 - index i holds the name of the local var
+				BSScrapArray<BSFixedString> localTypeArray;      // 80 - index i holds the type of said local var from above
+				InstructionStream           instructionStream;   // A0
+			};
+			static_assert(sizeof(Function) == 0xE8);
+
+			struct FunctionDebugInfo
+			{
+			public:
+				// members
+				std::uint32_t               functionType;            // 00
+				BSFixedString               className;               // 08
+				BSFixedString               stateName;               // 10
+				BSFixedString               functionName;            // 18
+				BSScrapArray<std::uint16_t> instructionLineNumbers;  // 20
+			};
+			static_assert(sizeof(FunctionDebugInfo) == 0x40);
+
+			struct Property
+			{
+			public:
+				// members
+				std::uint32_t flags;         // 00
+				std::uint32_t pad04;         // 04
+				BSFixedString typeName;      // 08
+				Function*     readHandler;   // 10 - get() function for the property
+				Function*     writeHandler;  // 18 - set() function for the property
+				BSFixedString autoVarName;   // 20
+				BSFixedString docString;     // 28 - Requires loadDocStrings in CompiledScriptLoader to be true
+				std::uint32_t userFlags;     // 30
+				std::uint32_t pad34;         // 34
+			};
+			static_assert(sizeof(Property) == 0x38);
+
+			// Usage: Create an object with Create(), then pass to CompiledScriptLoader::GetClass() to fill it with information of a script class
+			// See: https://en.uesp.net/wiki/Skyrim_Mod:Compiled_Script_File_Format
+			// Note: This will only grab the raw unlinked data from the script, the game won't use the object when called like this
+			class Object
+			{
+				struct VariableData
+				{
+				public:
+					// members
+					BSFixedString typeName;  // 00
+					std::uint64_t flags;     // 08
+				};
+				static_assert(sizeof(VariableData) == 0x10);
+
+			public:
+				~Object();
+
+				static Object* Create();
+
+				TES_HEAP_REDEFINE_NEW();
+
+				// members
+				BSFixedString                                                              fileName;               // 00
+				std::uint64_t                                                              compilationTime;        // 08
+				BSFixedString                                                              userName;               // 10
+				BSFixedString                                                              computerName;           // 18
+				std::byte                                                                  loadDebugInformation;   // 20 - is set to loadDebugInfo from CompiledScriptLoader
+				std::uint64_t                                                              modificationTime;       // 28
+				RE::BSScrapArray<FunctionDebugInfo*>                                       functionDebugInfoList;  // 30 - requires loadDebugInfo in CompiledScriptLoader to be true
+				BSTHashMap<BSFixedString, std::byte>                                       userFlagMap;            // 50
+				BSFixedString                                                              className;              // 80
+				BSFixedString                                                              parentClassName;        // 88
+				BSFixedString                                                              docString;              // 90 - requires loadDocStrings in CompiledScriptLoader to be true
+				std::uint32_t                                                              userFlags;              // 98
+				std::uint32_t                                                              pad_9C;                 // 9C
+				BSTScrapHashMap<BSFixedString, VariableData>                               variables;              // A0
+				BSTScrapHashMap<BSFixedString, Property*>                                  properties;             // D0
+				BSTScrapHashMap<BSFixedString, Function*>                                  staticFunctions;        // 100
+				BSTScrapHashMap<BSFixedString, Function*>                                  memberFunctions;        // 130 - Only has functions in empty state
+				BSTScrapHashMap<BSFixedString, BSTScrapHashMap<BSFixedString, Function*>*> stateMap;               // 160 - Does not include the empty state functions
+				std::uint32_t                                                              totalFunctions;         // 190 - staticFunctions size + memberFunctions size + all the state function variants in stateMap
+				std::uint32_t                                                              pad_194;                // 194
+				BSTScrapHashMap<BSFixedString, UnkValue[2]>                                initialVariableValues;  // 198
+				BSFixedString                                                              autoStateName;          // 1C8 - Is blank if no auto state in script
+
+			private:
+				void    Dtor();
+				Object* Ctor();
+			};
+			static_assert(sizeof(Object) == 0x1D0);
+		}
+	}
+}

--- a/src/RE/U/UnlinkedTypes.cpp
+++ b/src/RE/U/UnlinkedTypes.cpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "RE/U/UnlinkedTypes.h"
+
+#include "RE/M/MemoryManager.h"
+
+namespace RE
+{
+	namespace BSScript
+	{
+		namespace UnlinkedTypes
+		{
+			Object::~Object()
+			{
+				Dtor();
+				stl::memzero(this);
+			}
+
+			void Object::Dtor()
+			{
+				using func_t = decltype(&Object::Dtor);
+				REL::Relocation<func_t> func{ RELOCATION_ID(98654, 105309) };
+				return func(this);
+			}
+
+			Object* Object::Ctor()
+			{
+				using func_t = decltype(&Object::Ctor);
+				REL::Relocation<func_t> func{ RELOCATION_ID(98759, 105410) };
+				return func(this);
+			}
+
+			Object* Object::Create()
+			{
+				auto object = malloc<Object>();
+				std::memset(object, 0, sizeof(Object));
+				if (object) {
+					object->Ctor();
+				}
+				return object;
+			}
+		}
+	}
+}


### PR DESCRIPTION
See: https://en.uesp.net/wiki/Skyrim_Mod:Compiled_Script_File_Format for context behind member names. as those names reflect what is read from the script

Structure names taken from FO4 when possible, otherwise was given the best name possible

VTABLE was confirmed when doing hook testing of `GetClass` for REing UnlinkedType::Object. Additionally, confirmed `GetClass` worked on a new unlinked object, and was able to successfully print information about all the members of the object structure


VR addresses PR: https://github.com/alandtse/skyrim_vr_address_library/pull/31