### PR TITLE
More UnlinkedTypes RE

### DIFF
--- a/include/RE/L/LinkerProcessor.h
+++ b/include/RE/L/LinkerProcessor.h
@@ -18,6 +18,7 @@ namespace RE
 		{
 		public:
 			inline static constexpr auto RTTI = RTTI_BSScript__LinkerProcessor;
+			inline static constexpr auto VTABLE = VTABLE_BSScript__LinkerProcessor;
 
 			~LinkerProcessor() override;  // 00
 
@@ -30,7 +31,7 @@ namespace RE
 			IVirtualMachine*                                            vm;                  // 08
 			ErrorLogger*                                                errorHandler;        // 10
 			ILoader*                                                    loader;              // 18
-			std::uint64_t                                               unk20;               // 20
+			bool                                                        allowRelinking;      // 20 - whether to allow relinking when calling `Process` on already linked class
 			BSScrapArray<BSFixedString>                                 loadedParents;       // 28
 			BSScrapArray<BSFixedString>                                 objectsToTypecheck;  // 48
 			BSScrapArray<BSFixedString>                                 processQueue;        // 68


### PR DESCRIPTION
InstructionStream is moved out of UnlinkedTypes::Function as it is used in other structures

InstructionDefinition doesn't have any use in other structures yet, but it is used for correctly reading opcodes from a PEX script as part of InstructionStream reading.

Added VTABLE entry for LinkerProcessor. The VTABLE was already confirmed by myself previously and komplex earlier today, but forgot to add it in