### PR TITLE
RE INISettingCollection

### DIFF
--- a/include/RE/I/INIPrefSettingCollection.h
+++ b/include/RE/I/INIPrefSettingCollection.h
@@ -13,9 +13,9 @@ namespace RE
 		~INIPrefSettingCollection() override;  // 00
 
 		// override (INISettingCollection)
-		void Unk_07(void) override;  // 07 - { return 1; }
+		void Unk_07(void) override;        // 07 - { return 1; }
 		void WriteAllSettings() override;  // 08
-		void ReadAllSettings() override;  // 09
+		void ReadAllSettings() override;   // 09
 
 		static INIPrefSettingCollection* GetSingleton();
 	};

--- a/include/RE/I/INIPrefSettingCollection.h
+++ b/include/RE/I/INIPrefSettingCollection.h
@@ -8,13 +8,14 @@ namespace RE
 	{
 	public:
 		inline static constexpr auto RTTI = RTTI_INIPrefSettingCollection;
+		inline static constexpr auto VTABLE = VTABLE_INIPrefSettingCollection;
 
 		~INIPrefSettingCollection() override;  // 00
 
 		// override (INISettingCollection)
 		void Unk_07(void) override;  // 07 - { return 1; }
-		void Unk_08(void) override;  // 08
-		void Unk_09(void) override;  // 09
+		void WriteAllSettings() override;  // 08
+		void ReadAllSettings() override;  // 09
 
 		static INIPrefSettingCollection* GetSingleton();
 	};

--- a/include/RE/I/INISettingCollection.h
+++ b/include/RE/I/INISettingCollection.h
@@ -9,6 +9,7 @@ namespace RE
 	{
 	public:
 		inline static constexpr auto RTTI = RTTI_INISettingCollection;
+		inline static constexpr auto VTABLE = VTABLE_INISettingCollection;
 
 		~INISettingCollection() override;  // 00
 

--- a/include/RE/S/SettingCollection.h
+++ b/include/RE/S/SettingCollection.h
@@ -18,44 +18,12 @@ namespace RE
 		virtual bool OpenHandle(bool a_create);        // 05 - { return false; }
 		virtual bool CloseHandle();                    // 06 - { return true; }
 		virtual void Unk_07(void);                     // 07 - { return 0; }
-		virtual void Unk_08(void);                     // 08 - { return handle != 0; }
-		virtual void Unk_09(void);                     // 09 - { return handle != 0; }
+		virtual void WriteAllSettings();               // 08 - { return handle != 0; }
+		virtual void ReadAllSettings();                // 09 - { return handle != 0; }
 
 		// members
-		const char*   subKey;  // 008
-		std::uint64_t unk010;  // 010
-		std::uint64_t unk018;  // 018
-		std::uint64_t unk020;  // 020
-		std::uint64_t unk028;  // 028
-		std::uint64_t unk030;  // 030
-		std::uint64_t unk038;  // 038
-		std::uint64_t unk040;  // 040
-		std::uint64_t unk048;  // 048
-		std::uint64_t unk050;  // 050
-		std::uint64_t unk058;  // 058
-		std::uint64_t unk060;  // 060
-		std::uint64_t unk068;  // 068
-		std::uint64_t unk070;  // 070
-		std::uint64_t unk078;  // 078
-		std::uint64_t unk080;  // 080
-		std::uint64_t unk088;  // 088
-		std::uint64_t unk090;  // 090
-		std::uint64_t unk098;  // 098
-		std::uint64_t unk0A0;  // 0A0
-		std::uint64_t unk0A8;  // 0A8
-		std::uint64_t unk0B0;  // 0B0
-		std::uint64_t unk0B8;  // 0B8
-		std::uint64_t unk0C0;  // 0C0
-		std::uint64_t unk0C8;  // 0C8
-		std::uint64_t unk0D0;  // 0D0
-		std::uint64_t unk0D8;  // 0D8
-		std::uint64_t unk0E0;  // 0E0
-		std::uint64_t unk0E8;  // 0E8
-		std::uint64_t unk0F0;  // 0F0
-		std::uint64_t unk0F8;  // 0F8
-		std::uint64_t unk100;  // 100
-		std::uint64_t unk108;  // 108
-		void*         handle;  // 110
+		char  subKey[0x104];  // 008
+		void* handle;         // 110
 	};
 	static_assert(sizeof(SettingCollection<void*>) == 0x118);
 }

--- a/include/RE/S/SettingCollectionList.h
+++ b/include/RE/S/SettingCollectionList.h
@@ -14,8 +14,8 @@ namespace RE
 		// override (SettingCollection<T>)
 		void InsertSetting(T* a_setting) override;  // 01
 		void RemoveSetting(T* a_setting) override;  // 02
-		void Unk_08(void) override;                 // 08
-		void Unk_09(void) override;                 // 09
+		void WriteAllSettings() override;           // 08
+		void ReadAllSettings() override;            // 09
 
 		// members
 		BSSimpleList<T*> settings;  // 118

--- a/include/RE/S/SettingCollectionMap.h
+++ b/include/RE/S/SettingCollectionMap.h
@@ -15,8 +15,8 @@ namespace RE
 		// override (SettingCollection<T>)
 		void InsertSetting(T* a_setting) override;  // 01
 		void RemoveSetting(T* a_setting) override;  // 02
-		void Unk_08(void) override;                 // 08
-		void Unk_09(void) override;                 // 09
+		void WriteAllSettings() override;           // 08
+		void ReadAllSettings() override;            // 09
 
 		// members
 		BSTCaseInsensitiveStringMap<T*> settings;  // 118


### PR DESCRIPTION
VTABLEs confirmed with hooks for upcoming mod

WriteAllSettings(), ReadAllSettings() confirmed with static analysis and testing for upcoming mod. They both loop over all listed settings and call `WriteSetting`/`ReadSetting` respectively.

subKey size of 0x104 confirmed with logging, changing the key for upcoming mod and from static analysis where they copy INI path to the key:
```
        if ( Source != v7->SubKey_8 )
          strcpy_s_141509FC8(v7->SubKey_8, 0x104ui64, Source);
```