### PR TITLE
Update TLSData with cached ExtraData

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -1405,6 +1405,7 @@ set(SOURCES
 	include/RE/T/TESWeightForm.h
 	include/RE/T/TESWordOfPower.h
 	include/RE/T/TESWorldSpace.h
+	include/RE/T/TLSData.h
 	include/RE/T/TargetValueModifierEffect.h
 	include/RE/T/TaskQueueInterface.h
 	include/RE/T/TempEffectTraits.h

--- a/include/RE/Offsets.h
+++ b/include/RE/Offsets.h
@@ -502,6 +502,7 @@ namespace RE
 		inline constexpr REL::ID LookupReferenceByHandle(static_cast<std::uint64_t>(12332));
 		inline constexpr REL::ID PlaySound(static_cast<std::uint64_t>(52939));
 		inline constexpr REL::ID TlsIndex(static_cast<std::uint64_t>(415542));
+		inline constexpr REL::ID GlobalStateCounter(static_cast<std::uint64_t>(400305));
 #else
 		namespace Actor
 		{
@@ -998,6 +999,7 @@ namespace RE
 		inline constexpr REL::ID LookupReferenceByHandle(static_cast<std::uint64_t>(12204));
 		inline constexpr REL::ID PlaySound(static_cast<std::uint64_t>(52054));
 		inline constexpr REL::ID TlsIndex(static_cast<std::uint64_t>(528600));
+		inline constexpr REL::ID GlobalStateCounter(static_cast<std::uint64_t>(514157));
 #endif
 	}
 }

--- a/include/RE/Skyrim.h
+++ b/include/RE/Skyrim.h
@@ -1402,6 +1402,7 @@
 #include "RE/T/TESWeightForm.h"
 #include "RE/T/TESWordOfPower.h"
 #include "RE/T/TESWorldSpace.h"
+#include "RE/T/TLSData.h"
 #include "RE/T/TargetValueModifierEffect.h"
 #include "RE/T/TaskQueueInterface.h"
 #include "RE/T/TempEffectTraits.h"

--- a/include/RE/T/TLSData.h
+++ b/include/RE/T/TLSData.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "RE/E/ExtraDataList.h"
+#include "RE/E/ExtraDataTypes.h"
+#include "RE/B/BSExtraData.h"
+
+namespace RE {
+  struct TLSData
+  {
+    inline static constexpr uint32_t CACHED_EXTRA_DATA_SIZE = (static_cast<uint32_t>(ExtraDataType::kResourcesPreload) + 1);
+    std::uint8_t   unk000[0x10];                             // 000
+    std::uint32_t  stateCounter;                             // 010 - on GetExtraData(), this gets checked against the GlobalStateCounter, which is incremented every time extra data is changed or removed; if they're not equal, then the following cached extra data is zeroed-out and recached
+    std::uint32_t  pad014;                                   // 014
+    ExtraDataList* cachedExtraDataList;                      // 018
+    BSExtraData*   cachedExtraData[CACHED_EXTRA_DATA_SIZE];  // 020 - ExtraData types up to kResourcesPreload (0xB5) are cached
+    std::uint8_t   unk5D0[0x30];                             // 5D0
+    bool           consoleMode;                              // 600
+    // ... many others ...
+  };
+  static_assert(offsetof(TLSData, consoleMode) == 0x600);
+}

--- a/include/RE/T/TLSData.h
+++ b/include/RE/T/TLSData.h
@@ -18,4 +18,9 @@ namespace RE {
     // ... many others ...
   };
   static_assert(offsetof(TLSData, consoleMode) == 0x600);
+  inline static TLSData* GetStaticTLSData() {
+	REL::Relocation<std::uint32_t*> tlsIndex{ Offset::TlsIndex };
+	auto tlsDataArray = reinterpret_cast<TLSData**>(__readgsqword(0x58));
+	return tlsDataArray[*tlsIndex];
+  }
 }

--- a/src/RE/C/ConsoleLog.cpp
+++ b/src/RE/C/ConsoleLog.cpp
@@ -1,4 +1,5 @@
 #include "RE/C/ConsoleLog.h"
+#include "RE/T/TLSData.h"
 
 namespace RE
 {
@@ -10,12 +11,6 @@ namespace RE
 
 	bool ConsoleLog::IsConsoleMode()
 	{
-		struct TLSData
-		{
-			std::uint8_t unk000[0x600];  // 000
-			bool         consoleMode;    // 600
-		};
-
 		REL::Relocation<std::uint32_t*> tlsIndex{ Offset::TlsIndex };
 		auto                            tlsData = reinterpret_cast<TLSData**>(__readgsqword(0x58));
 		return tlsData[*tlsIndex]->consoleMode;

--- a/src/RE/C/ConsoleLog.cpp
+++ b/src/RE/C/ConsoleLog.cpp
@@ -11,9 +11,7 @@ namespace RE
 
 	bool ConsoleLog::IsConsoleMode()
 	{
-		REL::Relocation<std::uint32_t*> tlsIndex{ Offset::TlsIndex };
-		auto                            tlsData = reinterpret_cast<TLSData**>(__readgsqword(0x58));
-		return tlsData[*tlsIndex]->consoleMode;
+		return GetStaticTLSData()->consoleMode;
 	}
 
 	void ConsoleLog::Print(const char* a_fmt, ...)


### PR DESCRIPTION
I've RE'd how the ExtraData is cached in the TLS; as such I've moved TLSData from ConsoleLog into its own separate header.

To support the above, I've added the offset to the GlobalStateCounter to Offsets.h

I've also added a `GetStaticTLSData()`, but can you please double check to see if this is correct? I think that the `__readgsqword(0x58)` call will work whether or not it's inlined (it doesn't get inlined for debug builds), but I am not certain.