### PR TITLE
fix BaseExtraList::PresenceBitfield::HasType index checking

### DIFF
--- a/src/RE/E/ExtraDataList.cpp
+++ b/src/RE/E/ExtraDataList.cpp
@@ -38,7 +38,7 @@ namespace RE
 	bool BaseExtraList::PresenceBitfield::HasType(std::uint32_t a_type) const
 	{
 		const std::uint32_t index = (a_type >> 3);
-		if (index >= 0x18) {
+		if (index >= 0x17) {
 			return false;
 		}
 		const std::uint8_t bitMask = 1 << (a_type % 8);


### PR DESCRIPTION
AE, SE, and VR all check that the index >= 0x17, not 0x18