### PR TITLE
Add Inventory getters that do not initialize the inventory

### DIFF
--- a/include/RE/A/Actor.h
+++ b/include/RE/A/Actor.h
@@ -520,7 +520,7 @@ namespace RE
 		InventoryEntryData*          GetEquippedEntryData(bool a_leftHand) const;
 		TESForm*                     GetEquippedObject(bool a_leftHand) const;
 		float                        GetEquippedWeight();
-		std::int32_t                 GetGoldAmount();
+		std::int32_t                 GetGoldAmount(bool no_init = false);
 		ActorHandle                  GetHandle();
 		[[nodiscard]] NiAVObject*    GetHeadPartObject(BGSHeadPart::HeadPartType a_type);
 		float                        GetHeight();
@@ -532,13 +532,13 @@ namespace RE
 		TESRace*                     GetRace() const;
 		bool                         GetRider(NiPointer<Actor>& a_outRider);
 		[[nodiscard]] TESObjectARMO* GetSkin() const;
-		[[nodiscard]] TESObjectARMO* GetSkin(BGSBipedObjectForm::BipedObjectSlot a_slot);
+		[[nodiscard]] TESObjectARMO* GetSkin(BGSBipedObjectForm::BipedObjectSlot a_slot, bool no_init = false);
 		[[nodiscard]] SOUL_LEVEL     GetSoulSize() const;
 		TESFaction*                  GetVendorFaction();
 		const TESFaction*            GetVendorFaction() const;
 		float                        GetWarmthRating() const;
-		[[nodiscard]] TESObjectARMO* GetWornArmor(BGSBipedObjectForm::BipedObjectSlot a_slot);
-		[[nodiscard]] TESObjectARMO* GetWornArmor(FormID a_formID);
+		[[nodiscard]] TESObjectARMO* GetWornArmor(BGSBipedObjectForm::BipedObjectSlot a_slot, bool no_init = false);
+		[[nodiscard]] TESObjectARMO* GetWornArmor(FormID a_formID, bool no_init = false);
 		bool                         HasKeywordString(std::string_view a_formEditorID);
 		bool                         HasLineOfSight(TESObjectREFR* a_ref, bool& a_arg2);
 		bool                         HasOutfitItems(BGSOutfit* a_outfit);

--- a/include/RE/T/TESObjectREFR.h
+++ b/include/RE/T/TESObjectREFR.h
@@ -450,6 +450,8 @@ namespace RE
 		void                                    SetPosition(float a_x, float a_y, float a_z);
 		void                                    SetPosition(NiPoint3 a_pos);
 
+		static inline constexpr auto DEFAULT_INVENTORY_FILTER = [](TESBoundObject&) { return true; };
+
 		// members
 		OBJ_REFR         data;          // 40
 		TESObjectCELL*   parentCell;    // 60

--- a/include/RE/T/TESObjectREFR.h
+++ b/include/RE/T/TESObjectREFR.h
@@ -386,11 +386,11 @@ namespace RE
 		float                                   GetHeadingAngle(const RE::NiPoint3& a_pos, bool a_abs);
 		float                                   GetHeight() const;
 		InventoryItemMap                        GetInventory();
-		InventoryItemMap                        GetInventory(std::function<bool(TESBoundObject&)> a_filter);
-		std::int32_t                            GetInventoryCount();
+		InventoryItemMap                        GetInventory(std::function<bool(TESBoundObject&)> a_filter, bool no_init = false);
+		std::int32_t                            GetInventoryCount(bool no_init = false);
 		InventoryCountMap                       GetInventoryCounts();
-		InventoryCountMap                       GetInventoryCounts(std::function<bool(TESBoundObject&)> a_filter);
-		InventoryChanges*                       GetInventoryChanges();
+		InventoryCountMap                       GetInventoryCounts(std::function<bool(TESBoundObject&)> a_filter, bool no_init = false);
+		InventoryChanges*                       GetInventoryChanges(bool no_init = false);
 		TESObjectREFR*                          GetLinkedRef(BGSKeyword* a_keyword);
 		REFR_LOCK*                              GetLock() const;
 		LOCK_LEVEL                              GetLockLevel() const;

--- a/src/RE/A/Actor.cpp
+++ b/src/RE/A/Actor.cpp
@@ -342,11 +342,12 @@ namespace RE
 		return equippedWeight;
 	}
 
-	std::int32_t Actor::GetGoldAmount()
+	std::int32_t Actor::GetGoldAmount(bool no_init)
 	{
 		const auto inv = GetInventory([](TESBoundObject& a_object) -> bool {
 			return a_object.IsGold();
-		});
+		},
+			no_init);
 
 		const auto dobj = BGSDefaultObjectManager::GetSingleton();
 		if (!dobj) {
@@ -457,9 +458,9 @@ namespace RE
 		return nullptr;
 	}
 
-	TESObjectARMO* Actor::GetSkin(BGSBipedObjectForm::BipedObjectSlot a_slot)
+	TESObjectARMO* Actor::GetSkin(BGSBipedObjectForm::BipedObjectSlot a_slot, bool no_init)
 	{
-		if (const auto worn = GetWornArmor(a_slot); worn) {
+		if (const auto worn = GetWornArmor(a_slot, no_init); worn) {
 			return worn;
 		}
 		return GetSkin();
@@ -495,11 +496,11 @@ namespace RE
 		return func(this);
 	}
 
-	TESObjectARMO* Actor::GetWornArmor(BGSBipedObjectForm::BipedObjectSlot a_slot)
+	TESObjectARMO* Actor::GetWornArmor(BGSBipedObjectForm::BipedObjectSlot a_slot, bool no_init)
 	{
 		const auto inv = GetInventory([](TESBoundObject& a_object) {
 			return a_object.IsArmor();
-		});
+		}, no_init);
 
 		for (const auto& [item, invData] : inv) {
 			const auto& [count, entry] = invData;
@@ -514,11 +515,11 @@ namespace RE
 		return nullptr;
 	}
 
-	TESObjectARMO* Actor::GetWornArmor(FormID a_formID)
+	TESObjectARMO* Actor::GetWornArmor(FormID a_formID, bool no_init)
 	{
 		const auto inv = GetInventory([=](TESBoundObject& a_object) {
 			return a_object.IsArmor() && a_object.GetFormID() == a_formID;
-		});
+		}, no_init);
 
 		for (const auto& [item, invData] : inv) {
 			const auto& [count, entry] = invData;

--- a/src/RE/T/TESFaction.cpp
+++ b/src/RE/T/TESFaction.cpp
@@ -20,6 +20,7 @@ namespace RE
 		}
 
 		auto bounty = player->GetCrimeGoldValue(this);
+		// At this point, the player has already had their inventory initialized
 		return player->GetGoldAmount() >= static_cast<std::int32_t>(bounty);
 	}
 

--- a/src/RE/T/TESObjectREFR.cpp
+++ b/src/RE/T/TESObjectREFR.cpp
@@ -304,7 +304,7 @@ namespace RE
 	auto TESObjectREFR::GetInventory()
 		-> InventoryItemMap
 	{
-		return GetInventory([](TESBoundObject&) { return true; }, false);
+		return GetInventory(DEFAULT_INVENTORY_FILTER, false);
 	}
 
 	auto TESObjectREFR::GetInventory(std::function<bool(TESBoundObject&)> a_filter, bool no_init)
@@ -363,7 +363,7 @@ namespace RE
 
 	std::int32_t TESObjectREFR::GetInventoryCount(bool no_init)
 	{
-		auto         counts = GetInventoryCounts([](TESBoundObject&) { return true; }, no_init);
+		auto         counts = GetInventoryCounts(DEFAULT_INVENTORY_FILTER, no_init);
 		std::int32_t total = 0;
 		for (auto& elem : counts) {
 			total += elem.second;
@@ -374,7 +374,7 @@ namespace RE
 	auto TESObjectREFR::GetInventoryCounts()
 		-> InventoryCountMap
 	{
-		return GetInventoryCounts([](TESBoundObject&) { return true; }, false);
+		return GetInventoryCounts(DEFAULT_INVENTORY_FILTER, false);
 	}
 
 	auto TESObjectREFR::GetInventoryCounts(std::function<bool(TESBoundObject&)> a_filter, bool no_init)

--- a/src/RE/T/TESObjectREFR.cpp
+++ b/src/RE/T/TESObjectREFR.cpp
@@ -301,19 +301,18 @@ namespace RE
 
 		return height;
 	}
-
 	auto TESObjectREFR::GetInventory()
 		-> InventoryItemMap
 	{
-		return GetInventory([](TESBoundObject&) { return true; });
+		return GetInventory([](TESBoundObject&) { return true; }, false);
 	}
 
-	auto TESObjectREFR::GetInventory(std::function<bool(TESBoundObject&)> a_filter)
+	auto TESObjectREFR::GetInventory(std::function<bool(TESBoundObject&)> a_filter, bool no_init)
 		-> InventoryItemMap
 	{
 		InventoryItemMap results;
 
-		auto invChanges = GetInventoryChanges();
+		auto invChanges = GetInventoryChanges(no_init);
 		if (invChanges && invChanges->entryList) {
 			for (auto& entry : *invChanges->entryList) {
 				if (entry && entry->object && a_filter(*entry->object)) {
@@ -362,9 +361,9 @@ namespace RE
 		return results;
 	}
 
-	std::int32_t TESObjectREFR::GetInventoryCount()
+	std::int32_t TESObjectREFR::GetInventoryCount(bool no_init)
 	{
-		auto         counts = GetInventoryCounts();
+		auto         counts = GetInventoryCounts([](TESBoundObject&) { return true; }, no_init);
 		std::int32_t total = 0;
 		for (auto& elem : counts) {
 			total += elem.second;
@@ -375,13 +374,13 @@ namespace RE
 	auto TESObjectREFR::GetInventoryCounts()
 		-> InventoryCountMap
 	{
-		return GetInventoryCounts([](TESBoundObject&) { return true; });
+		return GetInventoryCounts([](TESBoundObject&) { return true; }, false);
 	}
 
-	auto TESObjectREFR::GetInventoryCounts(std::function<bool(TESBoundObject&)> a_filter)
+	auto TESObjectREFR::GetInventoryCounts(std::function<bool(TESBoundObject&)> a_filter, bool no_init)
 		-> InventoryCountMap
 	{
-		auto              itemMap = GetInventory(std::move(a_filter));
+		auto              itemMap = GetInventory(std::move(a_filter), no_init);
 		InventoryCountMap results;
 		for (const auto& [key, value] : itemMap) {
 			results[key] = value.first;
@@ -389,9 +388,14 @@ namespace RE
 		return results;
 	}
 
-	InventoryChanges* TESObjectREFR::GetInventoryChanges()
+	// this does not behave like Skyrim's implementation; Skyrim's does not attempt to initialize the container.
+	// which is why we have to add "no_init" here if we don't want that to happen.
+	InventoryChanges* TESObjectREFR::GetInventoryChanges(bool no_init)
 	{
 		if (!extraList.HasType<ExtraContainerChanges>()) {
+			if (no_init) {
+				return nullptr;
+			}
 			if (!InitInventoryIfRequired()) {
 				ForceInitInventoryChanges();
 			}


### PR DESCRIPTION
The implementation for `GetInventoryChanges()` in CLIB does not match that of the game; the game's does not attempt to initialize the inventory if it hasn't been already.

Initializing the inventory can have side-effects, like initializing the leveled items. This is undesirable in many circumstances. In order to avoid this, we have to add "NoInit" versions of the calls that end up calling `GetInventoryChanges()` (like `GetInventory()`, `GetGoldAmount()`, `GetWornArmor()`, etc.

The reason for not changing the current implementation of `GetInventoryChanges` is that I know that more than a few mods depend on `GetInventoryChanges()` initializing the inventory if it hasn't already, and I did not want to break those. If you want me to, I can just change this around so that the default calls don't initialize the inventory, or change signatures, etc.