### PR TITLE
Magic: ActiveEffect, MagicItem, MagicTarget

### DIFF
--- a/include/RE/A/ActiveEffect.h
+++ b/include/RE/A/ActiveEffect.h
@@ -43,7 +43,9 @@ namespace RE
 		enum class Flag
 		{
 			kHasConditions = 1 << 7,
+			kEnchanting = 1 << 8,
 			kRecovers = 1 << 9,
+			kDual = 1 << 12,
 			kInactive = 1 << 15,
 			kDispelled = 1 << 18
 		};
@@ -88,6 +90,7 @@ namespace RE
 		[[nodiscard]] EffectSetting*       GetBaseObject() noexcept;
 		[[nodiscard]] const EffectSetting* GetBaseObject() const noexcept;
 		NiPointer<Actor>                   GetCasterActor() const;
+		float                              GetMagnitude(ActiveEffect* a_effect) const;
 		Actor*                             GetTargetActor();
 		const Actor*                       GetTargetActor() const;
 

--- a/include/RE/M/MagicItem.h
+++ b/include/RE/M/MagicItem.h
@@ -28,6 +28,55 @@ namespace RE
 	public:
 		inline static constexpr auto RTTI = RTTI_MagicItem;
 
+		class MagicItemTraversalFunctor
+		{
+		public:
+			inline static constexpr auto RTTI = RTTI_MagicItemTraversalFunctor;
+
+			virtual ~MagicItemTraversalFunctor(){};  // 00
+
+			// add
+			virtual BSContainer::ForEachResult Accept(Effect* a_effect) = 0;
+		};
+
+		class MagicItemDataCollector : public MagicItemTraversalFunctor
+		{
+		public:
+			inline static constexpr auto RTTI = RTTI_MagicItemDataCollector;
+
+			enum class Flags : uint32_t
+			{
+				kNone = 0,
+				kSkipCostiest = 1 << 0,
+				kSkipProjectiles = 1 << 1,
+				kSkipArea = 1 << 2,
+				kOnlyFirstEffect = 1 << 3
+			};
+
+			// override (MagicItemTraversalFunctor)
+			BSContainer::ForEachResult Accept([[maybe_unused]] Effect* a_effect) override
+			{
+				return BSContainer::ForEachResult::kContinue;
+			};  // actual function set in ctor
+
+			MagicItemDataCollector() = delete;
+			MagicItemDataCollector(const MagicItem* a_mitem);
+			~MagicItemDataCollector(){};
+
+			// members
+			uint64_t                          unk08;                // 08
+			BSTArray<Effect*>                 effectsProjectile;    // 10
+			Effect*                           costiestEffect;       // 28
+			uint32_t                          maxCost;              // 30
+			uint32_t                          pad34;                // 34
+			Effect*                           largestAreaEffect;    // 38
+			float                             maxArea;              // 40
+			stl::enumeration<Flags, uint32_t> flags;                // 44
+			bool                              hasExtraLargeSummon;  // 48
+			char                              pad49[7];             // 49
+		};
+		static_assert(sizeof(MagicItemDataCollector) == 0x50);
+
 		class PreloadableVisitor
 		{
 		public:
@@ -107,11 +156,15 @@ namespace RE
 
 		float                     CalculateMagickaCost(Actor* a_caster) const;
 		float                     CalculateTotalGoldValue(Actor* a_caster = nullptr) const;
+		MagicItemDataCollector    CollectData() const;
 		EffectSetting*            GetAVEffectSetting() const;
-		Effect*                   GetCostliestEffectItem(std::uint32_t a_arg1 = 5, bool a_arg2 = false);
+		Effect*                   GetCostliestEffectItem(MagicSystem::Delivery a_delivery = MagicSystem::Delivery::kTotal, bool a_positiveArea = false) const;
 		Data*                     GetData();
 		[[nodiscard]] const Data* GetData() const;
+		uint32_t                  GetLargestArea() const;
+		uint32_t                  GetLongestDuration() const;
 		bool                      IsPermanent() const;
+		void                      VisitEffects(MagicItemTraversalFunctor& visitor) const;
 
 		// members
 		BSTArray<Effect*>           effects;          // 58

--- a/include/RE/M/MagicSystem.h
+++ b/include/RE/M/MagicSystem.h
@@ -39,7 +39,9 @@ namespace RE
 			kTouch = 1,
 			kAimed = 2,
 			kTargetActor = 3,
-			kTargetLocation = 4
+			kTargetLocation = 4,
+
+			kTotal
 		};
 
 		enum class SoundID

--- a/include/RE/M/MagicTarget.h
+++ b/include/RE/M/MagicTarget.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "RE/B/BSContainer.h"
 #include "RE/B/BSPointerHandle.h"
 #include "RE/B/BSTList.h"
 #include "RE/B/BSTSmartPointer.h"
@@ -31,10 +32,10 @@ namespace RE
 		public:
 			inline static constexpr auto RTTI = RTTI_MagicTarget__ForEachActiveEffectVisitor;
 
-			virtual ~ForEachActiveEffectVisitor();  // 00
+			virtual ~ForEachActiveEffectVisitor(){};  // 00
 
 			// add
-			virtual bool Accept(ActiveEffect* a_effect) = 0;  // 01
+			virtual BSContainer::ForEachResult Accept(ActiveEffect* a_effect) = 0;  // 01
 		};
 		static_assert(sizeof(ForEachActiveEffectVisitor) == 0x8);
 
@@ -86,6 +87,7 @@ namespace RE
 		void DispelEffectsWithArchetype(Archetype a_type, bool a_force);
 		bool HasEffectWithArchetype(Archetype a_type);
 		bool HasMagicEffect(EffectSetting* a_effect);
+		void VisitEffects(ForEachActiveEffectVisitor& visitor);
 
 		// members
 		SpellDispelData* postUpdateDispelList;  // 08

--- a/include/RE/Offsets.h
+++ b/include/RE/Offsets.h
@@ -802,6 +802,7 @@ namespace RE
 		namespace MagicTarget
 		{
 			inline constexpr REL::ID HasMagicEffect(static_cast<std::uint64_t>(33733));
+			inline constexpr REL::ID VisitEffects(static_cast<std::uint64_t>(33756));
 		}
 
 		namespace Main

--- a/src/RE/A/ActiveEffect.cpp
+++ b/src/RE/A/ActiveEffect.cpp
@@ -44,4 +44,11 @@ namespace RE
 			return nullptr;
 		}
 	}
+
+	float ActiveEffect::GetMagnitude(ActiveEffect* a_effect) const
+	{
+		using func_t = decltype(&ActiveEffect::GetMagnitude);
+		REL::Relocation<func_t> func{ RELOCATION_ID(33282, 0) };  // I do not know for AE
+		return func(this, a_effect);
+	}
 }

--- a/src/RE/M/MagicItem.cpp
+++ b/src/RE/M/MagicItem.cpp
@@ -12,6 +12,13 @@ namespace RE
 		return CalculateCost(a_caster);
 	}
 
+	MagicItem::MagicItemDataCollector MagicItem::CollectData() const
+	{
+		MagicItemDataCollector ans(this);
+		this->VisitEffects(ans);
+		return ans;
+	}
+
 	EffectSetting* MagicItem::GetAVEffectSetting() const
 	{
 		using func_t = decltype(&MagicItem::GetAVEffectSetting);
@@ -19,11 +26,11 @@ namespace RE
 		return func(this);
 	}
 
-	Effect* MagicItem::GetCostliestEffectItem(std::uint32_t a_arg1, bool a_arg2)
+	Effect* MagicItem::GetCostliestEffectItem(MagicSystem::Delivery a_delivery, bool a_positiveArea) const
 	{
 		using func_t = decltype(&MagicItem::GetCostliestEffectItem);
 		REL::Relocation<func_t> func{ Offset::MagicItem::GetCostliestEffectItem };
-		return func(this, a_arg1, a_arg2);
+		return func(this, a_delivery, a_positiveArea);
 	}
 
 	float MagicItem::CalculateCost(Actor* a_caster) const
@@ -45,10 +52,38 @@ namespace RE
 		return GetData1();
 	}
 
+	uint32_t MagicItem::GetLargestArea() const
+	{
+		using func_t = decltype(&MagicItem::GetLargestArea);
+		REL::Relocation<func_t> func{ RELOCATION_ID(11219, 0) };  // I do not know for AE
+		return func(this);
+	}
+
+	uint32_t MagicItem::GetLongestDuration() const
+	{
+		using func_t = decltype(&MagicItem::GetLongestDuration);
+		REL::Relocation<func_t> func{ RELOCATION_ID(11218, 0) };  // I do not know for AE
+		return func(this);
+	}
+
 	bool MagicItem::IsPermanent() const
 	{
 		using func_t = decltype(&MagicItem::IsPermanent);
 		REL::Relocation<func_t> func{ RELOCATION_ID(11183, 11290) };
 		return func(this);
+	}
+
+	void MagicItem::VisitEffects(MagicItemTraversalFunctor& visitor) const
+	{
+		using func_t = decltype(&MagicItem::VisitEffects);
+		REL::Relocation<func_t> func{ RELOCATION_ID(11222, 0) };  // I do not know for AE
+		return func(this, visitor);
+	}
+
+	MagicItem::MagicItemDataCollector::MagicItemDataCollector(const MagicItem* a_mitem)
+	{
+		using func_t = void (MagicItemDataCollector* a, const MagicItem* a_mitem);
+		REL::Relocation<func_t> func{ RELOCATION_ID(33407, 0) };  // I do not know for AE
+		func(this, a_mitem);
 	}
 }

--- a/src/RE/M/MagicItem.cpp
+++ b/src/RE/M/MagicItem.cpp
@@ -82,7 +82,7 @@ namespace RE
 
 	MagicItem::MagicItemDataCollector::MagicItemDataCollector(const MagicItem* a_mitem)
 	{
-		using func_t = void (MagicItemDataCollector* a, const MagicItem* a_mitem);
+		using func_t = void(MagicItemDataCollector * a, const MagicItem* a_mitem);
 		REL::Relocation<func_t> func{ RELOCATION_ID(33407, 0) };  // I do not know for AE
 		func(this, a_mitem);
 	}

--- a/src/RE/M/MagicTarget.cpp
+++ b/src/RE/M/MagicTarget.cpp
@@ -56,4 +56,11 @@ namespace RE
 		REL::Relocation<func_t> func{ Offset::MagicTarget::HasMagicEffect };
 		return func(this, a_effect);
 	}
+
+	void MagicTarget::VisitEffects(ForEachActiveEffectVisitor& visitor)
+	{
+		using func_t = decltype(&MagicTarget::VisitEffects);
+		REL::Relocation<func_t> func{ Offset::MagicTarget::VisitEffects };
+		return func(this, visitor);
+	}
 }


### PR DESCRIPTION
Added:
* Some ActiveEffect flags
* ActiveEffect::GetMagnitude
* MagicItem::MagicItemTraversalFunctor and MagicItem::MagicItemDataCollector
* Some MagicItem functions that uses derived from MagicItemTraversalFunctor visitors
* MagicItem::CollectData that gets some Item's data that is used for some functions
* MagicTarget::ForEachActiveEffectVisitor
