### PR TITLE
RE BSInputDevice classes

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -277,6 +277,7 @@ set(SOURCES
 	include/RE/B/BSOrderedNode.h
 	include/RE/B/BSPCGamepadDeviceDelegate.h
 	include/RE/B/BSPCGamepadDeviceHandler.h
+	include/RE/B/BSPCOrbisGamepadDevice.h
 	include/RE/B/BSParticleShaderCubeEmitter.h
 	include/RE/B/BSParticleShaderEmitter.h
 	include/RE/B/BSParticleShaderObjectEmitter.h

--- a/include/RE/B/BSIInputDevice.h
+++ b/include/RE/B/BSIInputDevice.h
@@ -14,10 +14,10 @@ namespace RE
 		// add
 		virtual void               Initialize() = 0;                                                  // 01
 		virtual void               Process(float a_arg1) = 0;                                         // 02
-		virtual void               Unk_03(void) = 0;                                                  // 03
+		virtual void               Release() = 0;                                                     // 03
 		virtual bool               GetKeyMapping(std::uint32_t a_key, BSFixedString& a_mapping) = 0;  // 04
 		virtual std::uint32_t      GetMappingKey(BSFixedString a_mapping) = 0;                        // 05
-		virtual void               Unk_06(void) = 0;                                                  // 06
+		virtual bool               GetMappedKeycode(std::uint32_t a_key, std::uint32_t& outKeyCode) = 0; // 06
 		[[nodiscard]] virtual bool IsEnabled() const = 0;                                             // 07
 		virtual void               Reset() = 0;                                                       // 08
 	};

--- a/include/RE/B/BSInputDevice.h
+++ b/include/RE/B/BSInputDevice.h
@@ -25,7 +25,7 @@ namespace RE
 		// override (BSIInputDevice)
 		bool               GetKeyMapping(std::uint32_t a_key, BSFixedString& a_mapping) override;  // 04
 		std::uint32_t      GetMappingKey(BSFixedString a_mapping) override;                        // 05
-		void               Unk_06(void) override;                                                  // 06
+		bool               GetMappedKeycode(std::uint32_t a_key, std::uint32_t& outKeyCode) override;  // 06
 		[[nodiscard]] bool IsEnabled() const override;                                             // 07 - { return true; }
 
 		[[nodiscard]] bool IsKeyboard() const;

--- a/include/RE/B/BSMouseDevice.h
+++ b/include/RE/B/BSMouseDevice.h
@@ -12,13 +12,10 @@ namespace RE
 		~BSMouseDevice() override;  // 00
 
 		// add
-		virtual void Unk_09(void);  // 09 - { return; }
+		virtual void Reinitialize(void);  // 09 - { return; }
 
 		// members
 		bool          backgroundMouse;  // 70
-		std::uint8_t  unk71;            // 71
-		std::uint16_t unk72;            // 72
-		std::uint32_t unk74;            // 74
 	};
 	static_assert(sizeof(BSMouseDevice) == 0x78);
 }

--- a/include/RE/B/BSPCGamepadDeviceDelegate.h
+++ b/include/RE/B/BSPCGamepadDeviceDelegate.h
@@ -16,7 +16,7 @@ namespace RE
 		// override (BSGamepadDevice)
 		void Initialize() override;           // 01 - { return; }
 		void Process(float a_arg1) override;  // 02 - { return; }
-		void Unk_03(void) override;           // 03 - { return; }
+		void Release() override;           // 03 - { return; }
 		void Reset() override;                // 08 - { return; }
 		void Unk_09(void) override;           // 09 - { return; }
 

--- a/include/RE/B/BSPCGamepadDeviceHandler.h
+++ b/include/RE/B/BSPCGamepadDeviceHandler.h
@@ -16,10 +16,10 @@ namespace RE
 		// override (BSIInputDevice)
 		void          Initialize() override;                                                  // 01
 		void          Process(float a_unk1) override;                                         // 02
-		void          Unk_03() override;                                                      // 03
+		void          Release() override;                                                      // 03
 		bool          GetKeyMapping(std::uint32_t a_key, BSFixedString& a_mapping) override;  // 04
 		std::uint32_t GetMappingKey(BSFixedString a_mapping) override;                        // 05
-		void          Unk_06() override;                                                      // 06
+		bool          GetMappedKeycode(std::uint32_t a_key, std::uint32_t& outKeyCode) override;                                                      // 06
 		bool          IsEnabled() const override;                                             // 07 - { return currentPCGamePadDelegate != 0; }
 		void          Reset() override;                                                       // 08
 

--- a/include/RE/B/BSPCOrbisGamepadDevice.h
+++ b/include/RE/B/BSPCOrbisGamepadDevice.h
@@ -1,0 +1,153 @@
+#pragma once
+
+#include "RE/B/BSPCGamepadDeviceDelegate.h"
+namespace RE
+{
+	// PS3/PS4 controller used via RAW HID polling
+	class BSPCOrbisGamepadDevice : public BSPCGamepadDeviceDelegate
+	{
+	public:
+		inline static constexpr auto RTTI = RTTI_BSPCOrbisGamepadDevice;
+
+		struct Keys
+		{
+			enum Key : std::uint32_t
+			{
+				// Masks for buttonState
+				// Key hardware value.  Matches SCE_PAD_BUTTON_* enum values on ORBIS
+				KUp = 0x0010,
+				kDown = 0x0040,
+				kLeft = 0x0080,
+				kRight = 0x0020,
+				kPS3_Start = 0x0008,
+				kPS3_Back = 0x00100000,
+				kPS3_L3 = 0x0002,
+				kPS3_R3 = 0x0004,
+				kPS3_LB = 0x0400,
+				kPS3_RB = 0x0800,
+				kPS3_A = 0x4000,
+				kPS3_B = 0x2000,
+				kPS3_X = 0x8000,
+				kPS3_Y = 0x1000,
+				// arbitrary values
+				kPS3_LT = 0x0009,
+				kPS3_RT = 0x000a,
+				kPS3_LS = 0x000b,
+				kPS3_RS = 0x000c,
+			};
+		};
+		using Key = Keys::Key;
+
+		// unused values are kept here because they may contain other buttons, like the touchpad
+		// Further investigation needed
+		struct ButtonState
+		{
+			bool _unused00: 1;        // 0x0001
+			bool L3: 1;               // 0x0002
+			bool R3: 1;               // 0x0004
+			bool PS3_Start: 1;        // 0x0008
+			bool Up: 1;               // 0x0010
+			bool Right: 1;            // 0x0020
+			bool Down: 1;             // 0x0040
+			bool Left: 1;             // 0x0080
+			bool _unused100: 1;       // 0x0100
+			bool _unused200: 1;       // 0x0200
+			bool LB: 1;               // 0x0400
+			bool RB: 1;               // 0x0800
+			bool Y: 1;                // 0x1000 (Triangle)
+			bool B: 1;                // 0x2000 (Circle)
+			bool A: 1;                // 0x4000 (Cross)
+			bool X: 1;                // 0x8000 (Square)
+			bool _unused10000: 1;     // 0x00010000
+			bool _unused20000: 1;     // 0x00020000
+			bool _unused40000: 1;     // 0x00040000
+			bool _unused80000: 1;     // 0x00080000
+			bool Back: 1;             // 0x00100000
+			bool _unused200000: 1;    // 0x00200000
+			bool _unused400000: 1;    // 0x00400000
+			bool _unused800000: 1;    // 0x00800000
+			bool _unused1000000: 1;   // 0x01000000
+			bool _unused2000000: 1;   // 0x02000000
+			bool _unused4000000: 1;   // 0x04000000
+			bool _unused8000000: 1;   // 0x08000000
+			bool _unused10000000: 1;  // 0x10000000
+			bool _unused20000000: 1;  // 0x20000000
+			bool _unused40000000: 1;  // 0x40000000
+			bool _unused80000000: 1;  // 0x80000000
+		};
+		static_assert(sizeof(ButtonState) == 0x4);
+
+		// Note: This doesn't match the DS4 HID report data structure(s) known publicly.
+		// May be massaged somewhere else in the code, or a previously unknown HID report structure.
+		struct HIDState
+		{
+			std::uint32_t buttonState;         // 00 -- doesn't match publicly known HID data button fields, but works with button masks above
+			std::byte     rawLeftStickX;       // 04
+			std::byte     rawLeftStickY;       // 05
+			std::byte     rawRightStickX;      // 06
+			std::byte     rawRightStickY;      // 07
+			std::byte     rawLeftTrigger;      // 08
+			std::byte     rawRightTrigger;     // 09
+			std::byte     unk_0A;              // 0A
+			std::byte     unk_0B;              // 0B
+			std::uint32_t unk_0C;              // 0C  -- this is really a 64-bit value, but structure size is off if I try to insert an unaligned uint64_t
+			std::uint32_t unk_10;              // 10  -- part of the above 64-bit value
+			std::uint32_t unk_14;              // 14
+			std::uint32_t unk_18;              // 18
+			std::uint32_t unk_1C;              // 1C
+			std::uint64_t unk_20;              // 20
+			std::uint64_t unk_28;              // 28
+			std::uint32_t unk_30;              // 30
+			std::byte     unk_34;              // 34
+			std::byte     unk_35[23];          // 35
+			bool          hidDeviceConnected;  // 4C
+			std::byte     unk_4D[3];           // 4D
+			std::uint64_t unk_50;              // 50
+			std::byte     unk_58[16];          // 58
+			std::byte     unk_68;              // 68
+			std::byte     unk_69[15];          // 69
+		};
+		static_assert(sizeof(HIDState) == 0x78);
+
+		~BSPCOrbisGamepadDevice() override;  // 00
+
+		// override (BSPCGamepadDeviceDelegate)
+		void Initialize() override;                                                                   // 01
+		void Process(float a_arg1) override;                                                          // 02
+		void Release() override;                                                                      // 03
+		void Reset() override;                                                                        // 08 - { memset(this+0xD8, 0, 0x120); }
+		void Unk_09(void) override;                                                                   // 09 - takes two floats, and then does some HID polling
+		void Unk_0A(void) override;                                                                   // 0A - takes in a structure, and then does some HID polling
+		void Unk_0B(void) override;                                                                   // 0B - no params, does HID polling
+		void ProcessRawInput(int32_t a_rawX, int32_t a_rawY, float& a_outX, float& a_outY) override;  // 0D
+		void Unk_0E(void) override;                                                                   // 0E - { return; }
+
+		ButtonState GetPreviousButtonState()
+		{
+			return stl::unrestricted_cast<ButtonState>(previousHIDState.buttonState);
+		};
+
+		ButtonState GetCurrentButtonState()
+		{
+			return stl::unrestricted_cast<ButtonState>(currentHIDState.buttonState);
+		};
+
+		// members
+		HIDState previousHIDState;  // D8
+		float    previousLT;        // 150
+		float    previousRT;        // 154
+		float    previousLX;        // 158
+		float    previousLY;        // 15C
+		float    previousRX;        // 160
+		float    previousRY;        // 164
+		HIDState currentHIDState;   // 168
+		float    currentLT;         // 1E0
+		float    currentRT;         // 1E4
+		float    currentLX;         // 1E8
+		float    currentLY;         // 1EC
+		float    currentRX;         // 1F0
+		float    currentRY;         // 1F4
+	};
+	static_assert(sizeof(BSPCOrbisGamepadDevice) == 0x1F8);
+
+}

--- a/include/RE/B/BSWin32GamepadDevice.h
+++ b/include/RE/B/BSWin32GamepadDevice.h
@@ -4,6 +4,22 @@
 
 namespace RE
 {
+	// So we don't have to include XInput.h
+	struct __XINPUT_GAMEPAD
+	{
+		std::uint16_t wButtons;
+		std::byte     bLeftTrigger;
+		std::byte     bRightTrigger;
+		std::int16_t  sThumbLX;
+		std::int16_t  sThumbLY;
+		std::int16_t  sThumbRX;
+		std::int16_t  sThumbRY;
+	};
+	struct __XINPUT_STATE
+	{
+		std::uint32_t    dwPacketNumber;
+		__XINPUT_GAMEPAD Gamepad;
+	};
 	class BSWin32GamepadDevice : public BSPCGamepadDeviceDelegate
 	{
 	public:
@@ -13,6 +29,7 @@ namespace RE
 		{
 			enum Key : std::uint32_t
 			{
+				// button masks for wButtons
 				kUp = 0x0001,
 				kDown = 0x0002,
 				kLeft = 0x0004,
@@ -29,42 +46,78 @@ namespace RE
 				kX = 0x4000,
 				kY = 0x8000,
 
+				// arbitrary values
 				kLeftTrigger = 0x0009,
 				kRightTrigger = 0x000A
 			};
 		};
 		using Key = Keys::Key;
 
+		struct ButtonState
+		{
+			bool up: 1;             // 0x0001
+			bool down: 1;           // 0x0002
+			bool left: 1;           // 0x0004
+			bool right: 1;          // 0x0008
+			bool start: 1;          // 0x0010
+			bool back: 1;           // 0x0020
+			bool leftThumb: 1;      // 0x0040
+			bool rightThumb: 1;     // 0x0080
+			bool leftShoulder: 1;   // 0x0100
+			bool rightShoulder: 3;  // 0x0200, skip over 2 bits (XInput documentation says the state of these two bits are undefined)
+			bool a: 1;              // 0x1000
+			bool b: 1;              // 0x2000
+			bool x: 1;              // 0x4000
+			bool y: 1;              // 0x8000
+		};
+
 		~BSWin32GamepadDevice() override;  // 00
 
 		// override (BSPCGamepadDeviceDelegate)
 		void Initialize() override;           // 01
 		void Process(float a_arg1) override;  // 02
-		void Unk_03(void) override;           // 03 - { return; }
+		void Release() override;              // 03 - { return; }
 		void Reset() override;                // 08 - { std::memset(&unk0D8, 0, 0x50); }
 		void Unk_09(void) override;           // 09 - { return; }
 
+		static constexpr uint32_t BUTTON_MASK = Key::kUp | Key::kDown | Key::kLeft | Key::kRight | Key::kStart | Key::kBack | Key::kLeftThumb | Key::kRightThumb | Key::kLeftShoulder | Key::kRightShoulder | Key::kA | Key::kB | Key::kX | Key::kY;
+		// helper functions
+
+		/**
+		 * Returns the previous ButtonState of the gamepad
+		 *
+		 * @return ButtonState
+		 */
+		ButtonState GetPreviousButtonState()
+		{
+			return stl::unrestricted_cast<ButtonState>(PreviousState.Gamepad.wButtons & BUTTON_MASK);
+		};
+
+		/**
+		 * Returns the current ButtonState of the gamepad
+		 *
+		 * @return ButtonState
+		 */
+		ButtonState GetCurrentButtonState()
+		{
+			return stl::unrestricted_cast<ButtonState>(CurrentState.Gamepad.wButtons & BUTTON_MASK);
+		};
+
 		// members
-		std::uint32_t unk0D8;     // 0D8
-		std::uint8_t  unk0DC;     // 0DC
-		std::uint8_t  curState;   // 0DD
-		std::uint16_t unk0DE;     // 0DE
-		std::uint64_t unk0E0;     // 0E0
-		std::uint64_t unk0E8;     // 0E8
-		float         curLX;      // 0F0
-		float         curLY;      // 0F4
-		float         curRX;      // 0F8
-		float         curRY;      // 0FC
-		std::uint32_t unk100;     // 100
-		std::uint8_t  unk104;     // 104
-		std::uint8_t  prevState;  // 105
-		std::uint16_t unk106;     // 106
-		std::uint64_t unk108;     // 108
-		std::uint64_t unk110;     // 110
-		float         prevLX;     // 118
-		float         prevLY;     // 11C
-		float         prevRX;     // 120
-		float         prevRY;     // 124
+		__XINPUT_STATE PreviousState;  // 0D8
+		float          PreviousLT;     // 0E8
+		float          PreviousRT;     // 0EC
+		float          PreviousLX;     // 0F0
+		float          PreviousLY;     // 0F4
+		float          PreviousRX;     // 0F8
+		float          PreviousRY;     // 0FC
+		__XINPUT_STATE CurrentState;   // 100
+		float          CurrentLT;      // 110
+		float          CurrentRT;      // 114
+		float          CurrentLX;      // 118
+		float          CurrentLY;      // 11C
+		float          CurrentRX;      // 120
+		float          CurrentRY;      // 124
 	};
 	static_assert(sizeof(BSWin32GamepadDevice) == 0x128);
 }

--- a/include/RE/B/BSWin32KeyboardDevice.h
+++ b/include/RE/B/BSWin32KeyboardDevice.h
@@ -4,6 +4,15 @@
 
 namespace RE
 {
+	struct __DIDEVICEOBJECTDATA {
+		std::uint32_t dwOfs;      // 00
+		std::uint32_t dwData;     // 04
+		std::uint32_t dwTimeStamp;// 08
+		std::uint32_t dwSequence; // 0C
+		std::uint32_t* uAppData;  // 10
+	};
+	static_assert(sizeof(__DIDEVICEOBJECTDATA) == 0x18);
+
 	class BSWin32KeyboardDevice : public BSKeyboardDevice
 	{
 	public:
@@ -14,7 +23,7 @@ namespace RE
 		// override (BSKeyboardDevice)
 		void Initialize() override;           // 01
 		void Process(float a_unk1) override;  // 02
-		void Unk_03(void) override;           // 03
+		void Release() override;              // 03
 		void Reset() override;                // 08 - { std::memset(&curState, 0, 0x200); }
 		void Unk_09(void) override;           // 09 - { return; }
 		void Unk_0A(void) override;           // 0A - { return; }
@@ -22,42 +31,13 @@ namespace RE
 		[[nodiscard]] bool IsPressed(std::uint32_t a_keyCode) const;
 
 		// members
-		std::uint64_t unk070;            // 070
-		std::uint64_t unk078;            // 078
-		std::uint64_t unk080;            // 080
-		std::uint64_t unk088;            // 088
-		std::uint64_t unk090;            // 090
-		std::uint64_t unk098;            // 098
-		std::uint64_t unk0A0;            // 0A0
-		std::uint64_t unk0A8;            // 0A8
-		std::uint64_t unk0B0;            // 0B0
-		std::uint64_t unk0B8;            // 0B8
-		std::uint64_t unk0C0;            // 0C0
-		std::uint64_t unk0C8;            // 0C8
-		std::uint64_t unk0D0;            // 0D0
-		std::uint64_t unk0D8;            // 0D8
-		std::uint64_t unk0E0;            // 0E0
-		std::uint64_t unk0E8;            // 0E8
-		std::uint64_t unk0F0;            // 0F0
-		std::uint64_t unk0F8;            // 0F8
-		std::uint64_t unk100;            // 100
-		std::uint64_t unk108;            // 108
-		std::uint64_t unk110;            // 110
-		std::uint64_t unk118;            // 118
-		std::uint64_t unk120;            // 120
-		std::uint64_t unk128;            // 128
-		std::uint64_t unk130;            // 130
-		std::uint64_t unk138;            // 138
-		std::uint64_t unk140;            // 140
-		std::uint64_t unk148;            // 148
-		std::uint64_t unk150;            // 150
-		std::uint64_t unk158;            // 158
-		std::uint64_t unk160;            // 160
-		std::uint8_t  curState[0x100];   // 168
-		std::uint8_t  prevState[0x100];  // 268
-		std::uint64_t unk368;            // 368
+		void * dInputDevice;                 // 070 -- IDirectInputDevice8A*
+		__DIDEVICEOBJECTDATA diObjData[10];  // 078
+		std::uint8_t  prevState[0x100];      // 168
+		std::uint8_t  curState[0x100];       // 268
+		bool                 capsLockOn;     // 368
 	};
-	static_assert(offsetof(BSWin32KeyboardDevice, curState) == 0x168);
-	static_assert(offsetof(BSWin32KeyboardDevice, prevState) == 0x268);
+	static_assert(offsetof(BSWin32KeyboardDevice, prevState) == 0x168);
+	static_assert(offsetof(BSWin32KeyboardDevice, curState) == 0x268);
 	static_assert(sizeof(BSWin32KeyboardDevice) == 0x370);
 }

--- a/include/RE/B/BSWin32MouseDevice.h
+++ b/include/RE/B/BSWin32MouseDevice.h
@@ -5,6 +5,13 @@
 
 namespace RE
 {
+	struct __DIMOUSESTATE2 {
+		std::int32_t lX;
+		std::int32_t lY;
+		std::int32_t lZ;
+		std::byte rgbButtons[8];
+	};
+
 	class BSWin32MouseDevice : public BSMouseDevice
 	{
 	public:
@@ -33,20 +40,16 @@ namespace RE
 		// override (BSMouseDevice)
 		void Initialize() override;           // 01
 		void Process(float a_arg1) override;  // 02
-		void Unk_03(void) override;           // 03
+		void Release() override;              // 03
 		void Reset() override;                // 08
-		void Unk_09(void) override;           // 09
+		void Reinitialize(void) override;     // 09
 
 		// members
-		std::uint64_t      unk78;  // 78
-		std::uint64_t      unk80;  // 80
-		std::uint64_t      unk88;  // 88
-		std::uint64_t      unk90;  // 90
-		std::uint64_t      unk98;  // 98
-		std::uint64_t      unkA0;  // A0
-		std::uint32_t      unkA8;  // A8
-		mutable BSSpinLock unkAC;  // AC
-		std::uint32_t      unkB4;  // B4
+		void *             dInputDevice;      // 78 - IDirectInputDevice8A*
+		__DIMOUSESTATE2    dInputPrevState;   // 80
+		__DIMOUSESTATE2    dInputNextState;   // 94
+		bool               notInitialized;    // A8
+		mutable BSSpinLock reinitializeLock;  // AC
 	};
 	static_assert(sizeof(BSWin32MouseDevice) == 0xB8);
 }

--- a/include/RE/B/BSWin32VirtualKeyboardDevice.h
+++ b/include/RE/B/BSWin32VirtualKeyboardDevice.h
@@ -14,7 +14,7 @@ namespace RE
 		// override (BSVirtualKeyboardDevice)
 		void Initialize() override;           // 01 - { return; }
 		void Process(float a_arg1) override;  // 02 - { return; }
-		void Unk_03(void) override;           // 03 - { return; }
+		void Release() override;           // 03 - { return; }
 		void Reset() override;                // 08 - { return; }
 		void Unk_0B(void) override;           // 0B - { return; }
 		void Unk_0C(void) override;           // 0C - { return; }

--- a/include/RE/Skyrim.h
+++ b/include/RE/Skyrim.h
@@ -279,6 +279,7 @@
 #include "RE/B/BSOrderedNode.h"
 #include "RE/B/BSPCGamepadDeviceDelegate.h"
 #include "RE/B/BSPCGamepadDeviceHandler.h"
+#include "RE/B/BSPCOrbisGamepadDevice.h"
 #include "RE/B/BSParticleShaderCubeEmitter.h"
 #include "RE/B/BSParticleShaderEmitter.h"
 #include "RE/B/BSParticleShaderObjectEmitter.h"


### PR DESCRIPTION
This fills out the rest of the fields of the BSInputDevice classes, adds names for the previously unknown functions `BSInputDevice::Unk03()` and `BSInputDevice::Unk06()`, adds name for `BSMouseDevice::Unk09()`.

Please note: previously the BSInputDevice classes had the fields for the Previous and Current state reversed. This was incorrect. The Current state comes AFTER the Previous state, as you can see here in IDA with the correct placement:

![image](https://user-images.githubusercontent.com/69168929/223557865-82f50ede-01af-4dfc-893d-3e8f78bee29e.png)

This also adds an initial BSPCOrbisGamepadDevice class, but it's not fully RE'd; I cannot find where the other Unk functions are called, and the HID data seems to be different from the publicly known HID descriptor reports. 