### PR TITLE
Change type of stagger in HitData.h to float

### DIFF
--- a/include/RE/H/HitData.h
+++ b/include/RE/H/HitData.h
@@ -66,7 +66,7 @@ namespace RE
 		float                                 percentBlocked;          // 5C
 		float                                 resistedPhysicalDamage;  // 60
 		float                                 resistedTypedDamage;     // 64
-		std::uint32_t                         stagger;                 // 68
+		float                                 stagger;                 // 68
 		float                                 sneakAttackBonus;        // 6C
 		float                                 bonusHealthDamageMult;   // 70
 		float                                 pushBack;                // 74


### PR DESCRIPTION
When interpreting the value as float, it usually ranges from between -2 and 2 (negative for things like a dragon tail whip), with no stagger resistance, an unblocked hit has this value be equal to the base stagger value of the weapon that hit you

That seems to make more sense than an uint which would only be 0 or some value in the 1b range