### PR TITLE
Remove `BSInputDevice` constructor related code

### DIFF
--- a/include/RE/B/BSIInputDevice.h
+++ b/include/RE/B/BSIInputDevice.h
@@ -11,7 +11,7 @@ namespace RE
 		inline static constexpr auto RTTI = RTTI_BSIInputDevice;
 		inline static constexpr auto VTABLE = VTABLE_BSIInputDevice;
 
-		virtual ~BSIInputDevice() = default;  // 00
+		virtual ~BSIInputDevice();  // 00
 
 		// add
 		virtual void               Initialize() = 0;                                                      // 01
@@ -22,11 +22,6 @@ namespace RE
 		virtual bool               GetMappedKeycode(std::uint32_t a_key, std::uint32_t& outKeyCode) = 0;  // 06
 		[[nodiscard]] virtual bool IsEnabled() const = 0;                                                 // 07
 		virtual void               Reset() = 0;                                                           // 08
-
-	protected:
-		friend class BSInputDeviceFactory;
-		TES_HEAP_REDEFINE_NEW();
-		BSIInputDevice() = default;
 	};
 	static_assert(sizeof(BSIInputDevice) == 0x8);
 }

--- a/include/RE/B/BSInputDevice.h
+++ b/include/RE/B/BSInputDevice.h
@@ -43,9 +43,6 @@ namespace RE
 		std::uint32_t                            pad0C;            // 0C
 		BSTHashMap<std::uint32_t, InputButton*>  deviceButtons;    // 10
 		BSTHashMap<BSFixedString, std::uint32_t> buttonNameIDMap;  // 40
-
-	protected:
-		BSInputDevice();
 	};
 	static_assert(sizeof(BSInputDevice) == 0x70);
 }

--- a/src/RE/B/BSInputDevice.cpp
+++ b/src/RE/B/BSInputDevice.cpp
@@ -23,15 +23,6 @@ namespace RE
 		return (it != deviceButtons.end()) && (it->second->heldDownSecs > 0.0f);
 	}
 
-	BSInputDevice::BSInputDevice() :
-		BSIInputDevice(),
-		pad0C(0),
-		deviceButtons(),
-		buttonNameIDMap()
-	{
-		device = INPUT_DEVICE::kNone;
-	}
-
 	bool BSInputDevice::LoadControlsDefinitionFile(const char* a_fileName)
 	{
 		using func_t = decltype(&BSInputDevice::LoadControlsDefinitionFile);


### PR DESCRIPTION
ref [#68](https://github.com/powerof3/CommonLibSSE/pull/68)
The added constructor (w/ new `BSDeviceFactory`) causes linker error attempting to call `BSInputDevice::IsPressed()` virtual function, this forces compiler to instantiate the class without any solid implementation of virtual functions of `BSInputDevice`.
