### PR TITLE
Altered CachedValueData and renamed permanentActorValueCache

### DIFF
--- a/include/RE/A/AIProcess.h
+++ b/include/RE/A/AIProcess.h
@@ -37,14 +37,15 @@ namespace RE
 	};
 	static_assert(sizeof(MiddleLowProcessData) == 0x4);
 
+
 	struct CachedValueData
 	{
 	public:
 		// members
-		bool          dirty;  // 0
-		std::uint8_t  pad1;   // 1
-		std::uint16_t pad2;   // 2
-		float         value;  // 4
+		float			value;   // 0
+		bool			invalid; // 4
+		std::uint8_t	pad5;   // 5
+		std::uint16_t	pad6;   // 6
 	};
 	static_assert(sizeof(CachedValueData) == 0x8);
 
@@ -93,7 +94,7 @@ namespace RE
 		stl::enumeration<BooleanValue, std::uint32_t> booleanValues;             // 28
 		stl::enumeration<Flags, std::uint32_t>        flags;                     // 2C
 		BSTArray<CachedValueData>                     actorValueCache;           // 30
-		BSTArray<CachedValueData>                     permanentActorValueCache;  // 48
+		BSTArray<CachedValueData>                     maxActorValueCache;		 // 48
 	};
 	static_assert(sizeof(CachedValues) == 0x60);
 

--- a/include/RE/D/DualValueModifierEffect.h
+++ b/include/RE/D/DualValueModifierEffect.h
@@ -26,8 +26,8 @@ namespace RE
 		virtual float      GetSecondaryAVWeight() const;     // 22
 
 		// members
-		ActorValue secondaryActorValue;  // 98
-		float      secondaryAVWeight;    // 9C
+		float			secondaryAVWeight;  // 98
+		std::uint32_t	pad9C;				// 9C
 	};
 	static_assert(sizeof(DualValueModifierEffect) == 0xA0);
 }


### PR DESCRIPTION
-Altered structure of CachedValueData
-Renamed dirty to invalid based on how native functions use the value 
-Renamed permanentActorValueCache to maxActorValueCache to reflect what function uses it.

-Removed secondaryAV, 0x9C doesn't seem to be used in its coresponding function, the load from save, nor the ctor likely making it padding. Moved secondaryAVWeight to 0x98.

Evidence on 1.5.97 for claims
1406923F0 (presumed InvalidateCacheMaxValue)
1406924E0 (presumed GetCachedMaxValue)
140692510 (presumed SetCachedMaxValue)
140692390 (presumed InvalidateCachedValue)
140692450 (presumed GetCachedValue)
140692480 (presumed SetCachedValue)
*Primary evidence for perm being max is the get and set functions only being used in max