### PR TITLE
Remove fmtlib, use std::format

### DIFF
--- a/include/RE/A/ActorValueList.h
+++ b/include/RE/A/ActorValueList.h
@@ -24,6 +24,7 @@ namespace RE
 	};
 }
 
+#ifdef FMT_VERSION
 namespace fmt
 {
 	template <>
@@ -43,6 +44,7 @@ namespace fmt
 		}
 	};
 }
+#endif
 
 #ifdef __cpp_lib_format
 namespace std

--- a/include/RE/E/EffectArchetypes.h
+++ b/include/RE/E/EffectArchetypes.h
@@ -69,6 +69,7 @@ namespace std
 	}
 }
 
+#ifdef FMT_VERSION
 namespace fmt
 {
 	template <>
@@ -87,6 +88,7 @@ namespace fmt
 		}
 	};
 }
+#endif
 
 #ifdef __cpp_lib_format
 namespace std

--- a/include/RE/F/FormTypes.h
+++ b/include/RE/F/FormTypes.h
@@ -291,6 +291,7 @@ namespace std
 	}
 }
 
+#ifdef FMT_VERSION
 namespace fmt
 {
 	template <>
@@ -309,6 +310,7 @@ namespace fmt
 		}
 	};
 }
+#endif
 
 #ifdef __cpp_lib_format
 namespace std

--- a/include/RE/M/MaterialIDs.h
+++ b/include/RE/M/MaterialIDs.h
@@ -106,6 +106,7 @@ namespace std
 	}
 }
 
+#ifdef FMT_VERSION
 namespace fmt
 {
 	template <>
@@ -124,6 +125,7 @@ namespace fmt
 		}
 	};
 }
+#endif
 
 #ifdef __cpp_lib_format
 namespace std

--- a/include/REL/Relocation.h
+++ b/include/REL/Relocation.h
@@ -482,7 +482,7 @@ namespace REL
 			auto handle = WinAPI::GetModuleHandle(_filename.c_str());
 			if (handle == nullptr) {
 				stl::report_and_fail(
-					fmt::format(
+					std::format(
 						"Failed to obtain module handle for: \"{0}\".\n"
 						"You have likely renamed the executable to something unexpected. "
 						"Renaming the executable back to \"{0}\" may resolve the issue."sv,
@@ -503,7 +503,7 @@ namespace REL
 				_version = *version;
 			} else {
 				stl::report_and_fail(
-					fmt::format(
+					std::format(
 						"Failed to obtain file version info for: {}\n"
 						"Please contact the author of this script extender plugin for further assistance."sv,
 						stl::utf16_to_utf8(_filename).value_or("<unicode conversion error>"s)));
@@ -580,7 +580,7 @@ namespace REL
                     });
 				if (it == _offset2id.end()) {
 					stl::report_and_fail(
-						fmt::format(
+						std::format(
 							"Failed to find the offset within the database: 0x{:08X}"sv,
 							a_offset));
 				}
@@ -624,7 +624,7 @@ namespace REL
 				});
 			if (it == _id2offset.end()) {
 				stl::report_and_fail(
-					fmt::format(
+					std::format(
 						"Failed to find the id within the address library: {}\n"
 						"This means this script extender plugin is incompatible with the address "
 						"library for this version of the game, and thus does not support it."sv,
@@ -649,7 +649,7 @@ namespace REL
 				if (format != 1) {
 #endif
 					stl::report_and_fail(
-						fmt::format(
+						std::format(
 							"Unsupported address library format: {}\n"
 							"This means this script extender plugin is incompatible with the address "
 							"library available for this version of the game, and thus does not "
@@ -695,7 +695,7 @@ namespace REL
 			const auto version = Module::get().version();
 			const auto filename =
 				stl::utf8_to_utf16(
-					fmt::format(
+					std::format(
 #ifdef SKYRIM_SUPPORT_AE
 						"Data/SKSE/Plugins/versionlib-{}.bin"sv,
 #else
@@ -735,7 +735,7 @@ namespace REL
 				}
 			} catch (const std::system_error&) {
 				stl::report_and_fail(
-					fmt::format(
+					std::format(
 						"Failed to locate an appropriate address library with the path: {}\n"
 						"This means you are missing the address library for this specific version of "
 						"the game. Please continue to the mod page for address library to download "
@@ -1105,7 +1105,7 @@ namespace REL
 				if (!this->match(a_address)) {
 					const auto version = Module::get().version();
 					stl::report_and_fail(
-						fmt::format(
+						std::format(
 							"A pattern has failed to match.\n"
 							"This means the plugin is incompatible with the current version of the game ({}.{}.{}). "
 							"Head to the mod page of this plugin to see if an update is available."sv,

--- a/include/SKSE/Impl/PCH.h
+++ b/include/SKSE/Impl/PCH.h
@@ -22,6 +22,7 @@
 #include <format>
 #include <fstream>
 #include <functional>
+#include <intrin.h>
 #include <iomanip>
 #include <ios>
 #include <istream>
@@ -59,7 +60,6 @@ static_assert(
 
 #pragma warning(push)
 #include <binary_io/file_stream.hpp>
-#include <fmt/format.h>
 #include <spdlog/spdlog.h>
 #pragma warning(pop)
 
@@ -599,7 +599,7 @@ namespace SKSE
 				}
 
 				return utf8_to_utf16(
-					fmt::format(
+					std::format(
 						"{}({}): {}"sv,
 						filename,
 						a_loc.line(),

--- a/include/SKSE/Logger.h
+++ b/include/SKSE/Logger.h
@@ -11,7 +11,7 @@
 		a_func() = delete;                                                \
                                                                           \
 		explicit a_func(                                                  \
-			fmt::format_string<Args...> a_fmt,                            \
+			spdlog::format_string_t<Args...> a_fmt,                       \
 			Args&&... a_args,                                             \
 			std::source_location a_loc = std::source_location::current()) \
 		{                                                                 \
@@ -27,7 +27,7 @@
 	};                                                                    \
                                                                           \
 	template <class... Args>                                              \
-	a_func(fmt::format_string<Args...>, Args&&...) -> a_func<Args...>;
+	a_func(spdlog::format_string_t<Args...>, Args&&...) -> a_func<Args...>;
 
 namespace SKSE::log
 {

--- a/src/RE/C/Color.cpp
+++ b/src/RE/C/Color.cpp
@@ -18,6 +18,6 @@ namespace RE
 
 	std::string Color::ToHex() const
 	{
-		return fmt::format("{:X}{:X}{:X}{:X}", red, green, blue, alpha);
+		return std::format("{:X}{:X}{:X}{:X}", red, green, blue, alpha);
 	}
 }

--- a/src/RE/N/NiColor.cpp
+++ b/src/RE/N/NiColor.cpp
@@ -25,7 +25,7 @@ namespace RE
 		auto g = static_cast<std::uint32_t>(green * 255);
 		auto b = static_cast<std::uint32_t>(blue * 255);
 
-		return fmt::format("{:X}{:X}{:X}", r, g, b);
+		return std::format("{:X}{:X}{:X}", r, g, b);
 	}
 
 	NiColorA::NiColorA(const Color& a_rhs) :

--- a/src/SKSE/Translation.cpp
+++ b/src/SKSE/Translation.cpp
@@ -58,7 +58,7 @@ namespace SKSE
 		// Construct translation filename
 		std::string language = (setting && setting->GetType() == RE::Setting::Type::kString) ? setting->data.s : "ENGLISH"s;
 
-		std::string path = fmt::format("Interface\\Translations\\{}_{}.txt"sv, a_name, language);
+		std::string path = std::format("Interface\\Translations\\{}_{}.txt"sv, a_name, language);
 
 		RE::BSResourceNiBinaryStream fileStream{ path };
 		if (!fileStream.good()) {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "supports": "windows & x64",
   "dependencies": [
-    "fmt",
     "rsm-binary-io",
     "spdlog"
   ]


### PR DESCRIPTION
`fmt::format_string` -> `spdlog::format_string_t` to allow backwards compatibility with existing fmt users