### PR TITLE
RE BSSoundHandle::Pause()

### DIFF
--- a/include/RE/B/BSSoundHandle.h
+++ b/include/RE/B/BSSoundHandle.h
@@ -42,7 +42,7 @@ namespace RE
 		bool               SetVolume(float a_volume);
 		bool               Stop();
 		bool               Play();
-		bool			   Pause();
+		bool               Pause();
 
 		// members
 		std::uint32_t                                 soundID;        // 00

--- a/include/RE/B/BSSoundHandle.h
+++ b/include/RE/B/BSSoundHandle.h
@@ -42,6 +42,7 @@ namespace RE
 		bool               SetVolume(float a_volume);
 		bool               Stop();
 		bool               Play();
+		bool			   Pause();
 
 		// members
 		std::uint32_t                                 soundID;        // 00

--- a/include/RE/Offsets.h
+++ b/include/RE/Offsets.h
@@ -727,6 +727,7 @@ namespace RE
 			inline constexpr REL::ID Play(static_cast<std::uint64_t>(66355));
 			inline constexpr REL::ID SetObjectToFollow(static_cast<std::uint64_t>(66375));
 			inline constexpr REL::ID SetPosition(static_cast<std::uint64_t>(66370));
+			inline constexpr REL::ID Pause(static_cast<std::uint64_t>(66357));
 			inline constexpr REL::ID Stop(static_cast<std::uint64_t>(66358));
 		}
 

--- a/include/RE/Offsets.h
+++ b/include/RE/Offsets.h
@@ -146,6 +146,7 @@ namespace RE
 			inline constexpr REL::ID Play(static_cast<std::uint64_t>(67616));
 			inline constexpr REL::ID SetObjectToFollow(static_cast<std::uint64_t>(67636));
 			inline constexpr REL::ID SetPosition(static_cast<std::uint64_t>(67631));
+			inline constexpr REL::ID Pause(static_cast<std::uint64_t>(67618));
 			inline constexpr REL::ID Stop(static_cast<std::uint64_t>(67619));
 		}
 

--- a/src/RE/B/BSSoundHandle.cpp
+++ b/src/RE/B/BSSoundHandle.cpp
@@ -81,4 +81,11 @@ namespace RE
 		REL::Relocation<func_t> func{ Offset::BSSoundHandle::Play };
 		return func(this);
 	}
+
+	bool BSSoundHandle::Pause()
+	{
+		using func_t = decltype(&BSSoundHandle::Pause);
+		REL::Relocation<func_t> func{ Offset::BSSoundHandle::Pause };
+		return func(this);
+	}
 }


### PR DESCRIPTION
Very similar to Play/Stop & offset isn't surprising (just off by one from Stop). Have verified the behavior in-game (turn sound on):

https://github.com/powerof3/CommonLibSSE/assets/3292122/c6e2246c-61ae-430d-a84d-1479dbc30831

Builds successfully:
```
[build] [336/336] Linking CXX static library _deps\clib-build\CommonLibSSE.lib
[driver] Build completed: 00:00:12.700
[build] Build finished with exit code 0
```