### PR TITLE
Fix functions in IMenu.h returning incorrect flags

### DIFF
--- a/include/RE/I/IMenu.h
+++ b/include/RE/I/IMenu.h
@@ -96,11 +96,11 @@ namespace RE
 		[[nodiscard]] constexpr bool RequiresUpdate() const noexcept { return menuFlags.all(Flag::kRequiresUpdate); }
 		[[nodiscard]] constexpr bool SkipRenderDuringFreezeFrameScreenshot() const noexcept { return menuFlags.all(Flag::kSkipRenderDuringFreezeFrameScreenshot); }
 		[[nodiscard]] constexpr bool TopmostRenderedMenu() const noexcept { return menuFlags.all(Flag::kTopmostRenderedMenu); }
-		[[nodiscard]] constexpr bool UpdateUsesCursor() const noexcept { return menuFlags.all(Flag::kUsesBlurredBackground); }
-		[[nodiscard]] constexpr bool UsesBlurredBackground() const noexcept { return menuFlags.all(Flag::kUsesCursor); }
-		[[nodiscard]] constexpr bool UsesCursor() const noexcept { return menuFlags.all(Flag::kUsesMenuContext); }
-		[[nodiscard]] constexpr bool UsesMenuContext() const noexcept { return menuFlags.all(Flag::kUsesMovementToDirection); }
-		[[nodiscard]] constexpr bool UsesMovementToDirection() const noexcept { return menuFlags.all(Flag::kUpdateUsesCursor); }
+		[[nodiscard]] constexpr bool UpdateUsesCursor() const noexcept { return menuFlags.all(Flag::kUpdateUsesCursor); }
+		[[nodiscard]] constexpr bool UsesBlurredBackground() const noexcept { return menuFlags.all(Flag::kUsesBlurredBackground); }
+		[[nodiscard]] constexpr bool UsesCursor() const noexcept { return menuFlags.all(Flag::kUsesCursor); }
+		[[nodiscard]] constexpr bool UsesMenuContext() const noexcept { return menuFlags.all(Flag::kUsesMenuContext); }
+		[[nodiscard]] constexpr bool UsesMovementToDirection() const noexcept { return menuFlags.all(Flag::kUsesMovementToDirection); }
 
 		// members
 		GPtr<GFxMovieView>                             uiMovie{ nullptr };              // 10

--- a/include/RE/N/NiBillboardNode.h
+++ b/include/RE/N/NiBillboardNode.h
@@ -47,7 +47,7 @@ namespace RE
 
 		void SetMode(FaceMode a_mode)
 		{
-			userFlags = (std::to_underlying(a_mode) << FACE_MODE_POS) | userFlags & ~FACE_MODE_MASK;
+			userFlags = static_cast<uint16_t>((std::to_underlying(a_mode) << FACE_MODE_POS) | userFlags & ~FACE_MODE_MASK);
 		}
 
 		// members


### PR DESCRIPTION
The last few flag accessor functions in IMenu.h are currently shuffled around and return flags with a different name.
I assume that the actual flag indices are correct, so I just changed which function returns what.