### PR TITLE
perf: make all relocations static

### DIFF
--- a/include/RE/A/ActorMagicCaster.h
+++ b/include/RE/A/ActorMagicCaster.h
@@ -72,7 +72,7 @@ namespace RE
 		void CheckAttachCastingArt()
 		{
 			using func_t = decltype(&ActorMagicCaster::CheckAttachCastingArt);
-			REL::Relocation<func_t> func{ RELOCATION_ID(33403, 34185) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(33403, 34185) };
 			return func(this);
 		}
 

--- a/include/RE/B/BGSDefaultObjectManager.h
+++ b/include/RE/B/BGSDefaultObjectManager.h
@@ -438,7 +438,7 @@ namespace RE
 		[[nodiscard]] static BGSDefaultObjectManager* GetSingleton()
 		{
 			using func_t = decltype(&BGSDefaultObjectManager::GetSingleton);
-			REL::Relocation<func_t> func{ RELOCATION_ID(10878, 13894) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(10878, 13894) };
 			return func();
 		}
 

--- a/include/RE/B/BGSEntryPoint.h
+++ b/include/RE/B/BGSEntryPoint.h
@@ -112,7 +112,7 @@ namespace RE
 		static void HandleEntryPoint(ENTRY_POINT a_entryPoint, Actor* a_perkOwner, Args... a_args)
 		{
 			using func_t = decltype(&BGSEntryPoint::HandleEntryPoint<Args...>);
-			REL::Relocation<func_t> func{ RELOCATION_ID(23073, 23526) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(23073, 23526) };
 			func(a_entryPoint, a_perkOwner, a_args...);
 		}
 	};

--- a/include/RE/B/BGSIdleCollection.h
+++ b/include/RE/B/BGSIdleCollection.h
@@ -46,7 +46,7 @@ namespace RE
 		BGSIdleCollection* Ctor()
 		{
 			using func_t = decltype(&BGSIdleCollection::Ctor);
-			REL::Relocation<func_t> func{ RELOCATION_ID(14127, 14227) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(14127, 14227) };
 			return func(this);
 		}
 		void CopyIdles(const std::vector<TESIdleForm*>& a_copiedData);

--- a/include/RE/B/BGSImpactManager.h
+++ b/include/RE/B/BGSImpactManager.h
@@ -56,13 +56,13 @@ namespace RE
 		bool PlayImpactEffect(TESObjectREFR* a_ref, BGSImpactDataSet* a_impactEffect, const BSFixedString& a_nodeName, NiPoint3& a_pickDirection, float a_pickLength, bool a_applyNodeRotation, bool a_useNodeLocalRotation)
 		{
 			using func_t = decltype(&BGSImpactManager::PlayImpactEffect);
-			REL::Relocation<func_t> func{ RELOCATION_ID(35320, 36215) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(35320, 36215) };
 			return func(this, a_ref, a_impactEffect, a_nodeName, a_pickDirection, a_pickLength, a_applyNodeRotation, a_useNodeLocalRotation);
 		}
 		bool PlayImpactDataSounds(ImpactSoundData& a_impactSoundData)
 		{
 			using func_t = decltype(&BGSImpactManager::PlayImpactDataSounds);
-			REL::Relocation<func_t> func{ RELOCATION_ID(35317, 36212) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(35317, 36212) };
 			return func(this, a_impactSoundData);
 		}
 	};

--- a/include/RE/B/BGSLoadGameBuffer.h
+++ b/include/RE/B/BGSLoadGameBuffer.h
@@ -16,7 +16,7 @@ namespace RE
 		void LoadDataEndian(void* a_data, std::uint32_t a_offset, std::uint32_t a_size)
 		{
 			using func_t = decltype(&BGSLoadGameBuffer::LoadDataEndian);
-			REL::Relocation<func_t> func{ RELOCATION_ID(35112, 36005) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(35112, 36005) };
 			return func(this, a_data, a_offset, a_size);
 		}
 

--- a/include/RE/B/BGSMaterialType.h
+++ b/include/RE/B/BGSMaterialType.h
@@ -41,7 +41,7 @@ namespace RE
 		static BGSMaterialType* GetMaterialType(MATERIAL_ID a_materialID)
 		{
 			using func_t = decltype(&BGSMaterialType::GetMaterialType);
-			REL::Relocation<func_t> func{ RELOCATION_ID(20529, 20968) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(20529, 20968) };
 			return func(a_materialID);
 		}
 

--- a/include/RE/B/BGSNumericIDIndex.h
+++ b/include/RE/B/BGSNumericIDIndex.h
@@ -19,13 +19,13 @@ namespace RE
 		[[nodiscard]] FormID GetNumericID() const
 		{
 			using func_t = decltype(&BGSNumericIDIndex::GetNumericID);
-			REL::Relocation<func_t> func{ RELOCATION_ID(35026, 35927) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(35026, 35927) };
 			return func(this);
 		}
 		void SetNumericID(FormID a_formID)
 		{
 			using func_t = decltype(&BGSNumericIDIndex::SetNumericID);
-			REL::Relocation<func_t> func{ RELOCATION_ID(35027, 35928) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(35027, 35928) };
 			return func(this, a_formID);
 		}
 

--- a/include/RE/B/BGSRelationship.h
+++ b/include/RE/B/BGSRelationship.h
@@ -62,7 +62,7 @@ namespace RE
 		static BGSRelationship* GetRelationship(TESNPC* a_npc1, TESNPC* a_npc2)
 		{
 			using func_t = decltype(&BGSRelationship::GetRelationship);
-			REL::Relocation<func_t> func{ RELOCATION_ID(23632, 24084) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(23632, 24084) };
 			return func(a_npc1, a_npc2);
 		}
 

--- a/include/RE/B/BGSSaveGameBuffer.h
+++ b/include/RE/B/BGSSaveGameBuffer.h
@@ -22,7 +22,7 @@ namespace RE
 		void SaveDataEndian(const void* a_data, std::uint32_t a_size)
 		{
 			using func_t = decltype(&BGSSaveGameBuffer::SaveDataEndian);
-			REL::Relocation<func_t> func{ RELOCATION_ID(35163, 36053) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(35163, 36053) };
 			return func(this, a_data, a_size);
 		}
 

--- a/include/RE/B/BGSSaveLoadGame.h
+++ b/include/RE/B/BGSSaveLoadGame.h
@@ -75,7 +75,7 @@ namespace RE
 		bool GetChange(TESForm* a_form, std::uint32_t a_changes)
 		{
 			using func_t = decltype(&BGSSaveLoadGame::GetChange);
-			REL::Relocation<func_t> func{ RELOCATION_ID(34655, 35577) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(34655, 35577) };
 			return func(this, a_form, a_changes);
 		}
 

--- a/include/RE/B/BGSStoryEventManager.h
+++ b/include/RE/B/BGSStoryEventManager.h
@@ -17,7 +17,7 @@ namespace RE
 		[[nodiscard]] static BGSStoryEventManager* GetSingleton()
 		{
 			using func_t = decltype(&BGSStoryEventManager::GetSingleton);
-			REL::Relocation<func_t> func{ RELOCATION_ID(22317, 22790) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(22317, 22790) };
 			return func();
 		}
 
@@ -37,7 +37,7 @@ namespace RE
 		std::uint32_t AddEvent_Impl(std::uint32_t a_index, const void* a_event)
 		{
 			using func_t = decltype(&BGSStoryEventManager::AddEvent_Impl);
-			REL::Relocation<func_t> func{ RELOCATION_ID(31576, 32359) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(31576, 32359) };
 			return func(this, a_index, a_event);
 		}
 	};

--- a/include/RE/B/BSDismemberSkinInstance.h
+++ b/include/RE/B/BSDismemberSkinInstance.h
@@ -35,7 +35,7 @@ namespace RE
 		void UpdateDismemberPartion(std::uint16_t a_slot, bool a_enable)
 		{
 			using func_t = decltype(&BSDismemberSkinInstance::UpdateDismemberPartion);
-			REL::Relocation<func_t> func{ RELOCATION_ID(15576, 15753) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(15576, 15753) };
 			return func(this, a_slot, a_enable);
 		}
 

--- a/include/RE/B/BSFaceGenAnimationData.h
+++ b/include/RE/B/BSFaceGenAnimationData.h
@@ -23,14 +23,14 @@ namespace RE
 		void Reset(float a_timer, bool a_resetExpression, bool a_resetModifierAndPhoneme, bool a_resetCustom, bool a_closeEyes)
 		{
 			using func_t = decltype(&BSFaceGenAnimationData::Reset);
-			REL::Relocation<func_t> func{ RELOCATION_ID(25977, 26586) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(25977, 26586) };
 			return func(this, a_timer, a_resetExpression, a_resetModifierAndPhoneme, a_resetCustom, a_closeEyes);
 		}
 
 		void SetExpressionOverride(std::int32_t a_idx, float a_value)
 		{
 			using func_t = decltype(&BSFaceGenAnimationData::SetExpressionOverride);
-			REL::Relocation<func_t> func{ RELOCATION_ID(25980, 26594) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(25980, 26594) };
 			return func(this, a_idx, a_value);
 		}
 

--- a/include/RE/B/BSFaceGenManager.h
+++ b/include/RE/B/BSFaceGenManager.h
@@ -44,7 +44,7 @@ namespace RE
 		void PrepareHeadPartForShaders(BSFaceGenNiNode* a_node, BGSHeadPart* a_headPart, TESNPC* a_npc)
 		{
 			using func_t = decltype(&BSFaceGenManager::PrepareHeadPartForShaders);
-			REL::Relocation<func_t> func{ RELOCATION_ID(26259, 26838) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(26259, 26838) };
 			return func(this, a_node, a_headPart, a_npc);
 		}
 

--- a/include/RE/B/BSFixedString.h
+++ b/include/RE/B/BSFixedString.h
@@ -191,14 +191,14 @@ namespace RE
 			inline BSFixedString* ctor8(const char* a_data)
 			{
 				using func_t = decltype(&BSFixedString::ctor8);
-				REL::Relocation<func_t> func{ RELOCATION_ID(67819, 69161) };
+				static REL::Relocation<func_t> func{ RELOCATION_ID(67819, 69161) };
 				return func(this, a_data);
 			}
 
 			inline BSFixedString* ctor16(const wchar_t* a_data)
 			{
 				using func_t = decltype(&BSFixedString::ctor16);
-				REL::Relocation<func_t> func{ RELOCATION_ID(67834, 69176) };
+				static REL::Relocation<func_t> func{ RELOCATION_ID(67834, 69176) };
 				return func(this, a_data);
 			}
 

--- a/include/RE/B/BSLightingShaderMaterial.h
+++ b/include/RE/B/BSLightingShaderMaterial.h
@@ -21,7 +21,7 @@ namespace RE
 		BSLightingShaderMaterial* Ctor()
 		{
 			using func_t = decltype(&BSLightingShaderMaterial::Ctor);
-			REL::Relocation<func_t> func{ RELOCATION_ID(100004, 106711) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(100004, 106711) };
 			return func(this);
 		}
 		friend class BSLightingShaderMaterialBase;

--- a/include/RE/B/BSLightingShaderMaterialEnvmap.h
+++ b/include/RE/B/BSLightingShaderMaterialEnvmap.h
@@ -38,7 +38,7 @@ namespace RE
 		BSLightingShaderMaterialEnvmap* Ctor()
 		{
 			using func_t = decltype(&BSLightingShaderMaterialEnvmap::Ctor);
-			REL::Relocation<func_t> func{ RELOCATION_ID(100021, 106728) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(100021, 106728) };
 			return func(this);
 		}
 		friend class BSLightingShaderMaterialBase;

--- a/include/RE/B/BSLightingShaderMaterialEye.h
+++ b/include/RE/B/BSLightingShaderMaterialEye.h
@@ -40,7 +40,7 @@ namespace RE
 		BSLightingShaderMaterialEye* Ctor()
 		{
 			using func_t = decltype(&BSLightingShaderMaterialEye::Ctor);
-			REL::Relocation<func_t> func{ RELOCATION_ID(100033, 106740) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(100033, 106740) };
 			return func(this);
 		}
 		friend class BSLightingShaderMaterialBase;

--- a/include/RE/B/BSLightingShaderMaterialFacegen.h
+++ b/include/RE/B/BSLightingShaderMaterialFacegen.h
@@ -35,7 +35,7 @@ namespace RE
 		BSLightingShaderMaterialFacegen* Ctor()
 		{
 			using func_t = decltype(&BSLightingShaderMaterialFacegen::Ctor);
-			REL::Relocation<func_t> func{ RELOCATION_ID(100077, 106784) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(100077, 106784) };
 			return func(this);
 		}
 		friend class BSLightingShaderMaterialBase;

--- a/include/RE/B/BSLightingShaderMaterialFacegenTint.h
+++ b/include/RE/B/BSLightingShaderMaterialFacegenTint.h
@@ -30,7 +30,7 @@ namespace RE
 		BSLightingShaderMaterialFacegenTint* Ctor()
 		{
 			using func_t = decltype(&BSLightingShaderMaterialFacegenTint::Ctor);
-			REL::Relocation<func_t> func{ RELOCATION_ID(100087, 106794) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(100087, 106794) };
 			return func(this);
 		}
 		friend class BSLightingShaderMaterialBase;

--- a/include/RE/B/BSLightingShaderMaterialGlowmap.h
+++ b/include/RE/B/BSLightingShaderMaterialGlowmap.h
@@ -33,7 +33,7 @@ namespace RE
 		BSLightingShaderMaterialGlowmap* Ctor()
 		{
 			using func_t = decltype(&BSLightingShaderMaterialGlowmap::Ctor);
-			REL::Relocation<func_t> func{ RELOCATION_ID(100045, 106752) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(100045, 106752) };
 			return func(this);
 		}
 		friend class BSLightingShaderMaterialBase;

--- a/include/RE/B/BSLightingShaderMaterialHairTint.h
+++ b/include/RE/B/BSLightingShaderMaterialHairTint.h
@@ -30,7 +30,7 @@ namespace RE
 		BSLightingShaderMaterialHairTint* Ctor()
 		{
 			using func_t = decltype(&BSLightingShaderMaterialHairTint::Ctor);
-			REL::Relocation<func_t> func{ RELOCATION_ID(100095, 106802) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(100095, 106802) };
 			return func(this);
 		}
 		friend class BSLightingShaderMaterialBase;

--- a/include/RE/B/BSLightingShaderMaterialLODLandscape.h
+++ b/include/RE/B/BSLightingShaderMaterialLODLandscape.h
@@ -35,7 +35,7 @@ namespace RE
 		BSLightingShaderMaterialLODLandscape* Ctor()
 		{
 			using func_t = decltype(&BSLightingShaderMaterialLODLandscape::Ctor);
-			REL::Relocation<func_t> func{ RELOCATION_ID(100110, 106817) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(100110, 106817) };
 			return func(this);
 		}
 		friend class BSLightingShaderMaterialBase;

--- a/include/RE/B/BSLightingShaderMaterialLandscape.h
+++ b/include/RE/B/BSLightingShaderMaterialLandscape.h
@@ -44,7 +44,7 @@ namespace RE
 		BSLightingShaderMaterialLandscape* Ctor()
 		{
 			using func_t = decltype(&BSLightingShaderMaterialLandscape::Ctor);
-			REL::Relocation<func_t> func{ RELOCATION_ID(100102, 106809) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(100102, 106809) };
 			return func(this);
 		}
 		friend class BSLightingShaderMaterialBase;

--- a/include/RE/B/BSLightingShaderMaterialMultiLayerParallax.h
+++ b/include/RE/B/BSLightingShaderMaterialMultiLayerParallax.h
@@ -43,7 +43,7 @@ namespace RE
 		BSLightingShaderMaterialMultiLayerParallax* Ctor()
 		{
 			using func_t = decltype(&BSLightingShaderMaterialMultiLayerParallax::Ctor);
-			REL::Relocation<func_t> func{ RELOCATION_ID(100125, 106832) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(100125, 106832) };
 			return func(this);
 		}
 		friend class BSLightingShaderMaterialBase;

--- a/include/RE/B/BSLightingShaderMaterialParallax.h
+++ b/include/RE/B/BSLightingShaderMaterialParallax.h
@@ -33,7 +33,7 @@ namespace RE
 		BSLightingShaderMaterialParallax* Ctor()
 		{
 			using func_t = decltype(&BSLightingShaderMaterialParallax::Ctor);
-			REL::Relocation<func_t> func{ RELOCATION_ID(100055, 106762) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(100055, 106762) };
 			return func(this);
 		}
 		friend class BSLightingShaderMaterialBase;

--- a/include/RE/B/BSLightingShaderMaterialParallaxOcc.h
+++ b/include/RE/B/BSLightingShaderMaterialParallaxOcc.h
@@ -37,7 +37,7 @@ namespace RE
 		BSLightingShaderMaterialParallaxOcc* Ctor()
 		{
 			using func_t = decltype(&BSLightingShaderMaterialParallaxOcc::Ctor);
-			REL::Relocation<func_t> func{ RELOCATION_ID(100065, 106772) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(100065, 106772) };
 			return func(this);
 		}
 		friend class BSLightingShaderMaterialBase;

--- a/include/RE/B/BSLightingShaderMaterialSnow.h
+++ b/include/RE/B/BSLightingShaderMaterialSnow.h
@@ -29,7 +29,7 @@ namespace RE
 		BSLightingShaderMaterialSnow* Ctor()
 		{
 			using func_t = decltype(&BSLightingShaderMaterialSnow::Ctor);
-			REL::Relocation<func_t> func{ RELOCATION_ID(100118, 106825) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(100118, 106825) };
 			return func(this);
 		}
 		friend class BSLightingShaderMaterialBase;

--- a/include/RE/B/BSPointerHandle.h
+++ b/include/RE/B/BSPointerHandle.h
@@ -210,14 +210,14 @@ namespace RE
 		static BSPointerHandle<T> GetHandle(T* a_ptr)
 		{
 			using func_t = decltype(&BSPointerHandleManagerInterface<T, Manager>::GetHandle);
-			REL::Relocation<func_t> func{ RELOCATION_ID(15967, 16212) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(15967, 16212) };
 			return func(a_ptr);
 		}
 
 		static bool GetSmartPointer(const BSPointerHandle<T>& a_handle, NiPointer<T>& a_smartPointerOut)
 		{
 			using func_t = decltype(&BSPointerHandleManagerInterface<T, Manager>::GetSmartPointer);
-			REL::Relocation<func_t> func{ RELOCATION_ID(12204, 12332) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(12204, 12332) };
 			return func(a_handle, a_smartPointerOut);
 		}
 	};

--- a/include/RE/B/BSScaleformExternalTexture.h
+++ b/include/RE/B/BSScaleformExternalTexture.h
@@ -27,21 +27,21 @@ namespace RE
 		bool LoadPNG(const BSFixedString& a_path)
 		{
 			using func_t = decltype(&BSScaleformExternalTexture::LoadPNG);
-			REL::Relocation<func_t> func{ RELOCATION_ID(80298, 82321) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(80298, 82321) };
 			return func(this, a_path);
 		}
 
 		void ReleaseTexture()
 		{
 			using func_t = decltype(&BSScaleformExternalTexture::ReleaseTexture);
-			REL::Relocation<func_t> func{ RELOCATION_ID(80294, 82317) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(80294, 82317) };
 			return func(this);
 		}
 
 		bool SetTexture(NiTexture* a_texture)
 		{
 			using func_t = decltype(&BSScaleformExternalTexture::SetTexture);
-			REL::Relocation<func_t> func{ RELOCATION_ID(80295, 82318) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(80295, 82318) };
 			return func(this, a_texture);
 		}
 

--- a/include/RE/B/BSScaleformImageLoader.h
+++ b/include/RE/B/BSScaleformImageLoader.h
@@ -33,14 +33,14 @@ namespace RE
 		bool AddTexture(BSScaleformExternalTexture& a_texture)
 		{
 			using func_t = decltype(&BSScaleformImageLoader::AddTexture);
-			REL::Relocation<func_t> func{ RELOCATION_ID(82382, 84469) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(82382, 84469) };
 			return func(this, a_texture);
 		}
 
 		void RemoveTexture(BSScaleformExternalTexture& a_texture)
 		{
 			using func_t = decltype(&BSScaleformImageLoader::RemoveTexture);
-			REL::Relocation<func_t> func{ RELOCATION_ID(82383, 84470) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(82383, 84470) };
 			return func(this, a_texture);
 		}
 

--- a/include/RE/B/BSShaderManager.h
+++ b/include/RE/B/BSShaderManager.h
@@ -78,7 +78,7 @@ namespace RE
 		static void GetTexture(const char* a_path, bool a_demand, NiPointer<NiTexture>& a_textureOut, bool a_isHeightMap)
 		{
 			using func_t = decltype(&BSShaderManager::GetTexture);
-			REL::Relocation<func_t> func{ RELOCATION_ID(98986, 105640) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(98986, 105640) };
 			return func(a_path, a_demand, a_textureOut, a_isHeightMap);
 		}
 	};

--- a/include/RE/B/BSStringPool.h
+++ b/include/RE/B/BSStringPool.h
@@ -26,14 +26,14 @@ namespace RE
 			static inline void release8(const char*& a_entry)
 			{
 				using func_t = decltype(&Entry::release8);
-				REL::Relocation<func_t> func{ RELOCATION_ID(67847, 69192) };
+				static REL::Relocation<func_t> func{ RELOCATION_ID(67847, 69192) };
 				func(a_entry);
 			}
 
 			static inline void release16(const wchar_t*& a_entry)
 			{
 				using func_t = decltype(&Entry::release16);
-				REL::Relocation<func_t> func{ RELOCATION_ID(67848, 69193) };
+				static REL::Relocation<func_t> func{ RELOCATION_ID(67848, 69193) };
 				func(a_entry);
 			}
 

--- a/include/RE/B/BSTempEffectParticle.h
+++ b/include/RE/B/BSTempEffectParticle.h
@@ -33,13 +33,13 @@ namespace RE
 		static BSTempEffectParticle* Spawn(TESObjectCELL* a_cell, float a_lifetime, const char* a_modelName, const NiPoint3& a_rotation, const NiPoint3& a_position, float a_scale, std::uint32_t a_flags, NiAVObject* a_target)
 		{
 			using func_t = BSTempEffectParticle* (*)(TESObjectCELL*, float, const char*, const NiPoint3&, const NiPoint3&, float, std::uint32_t, NiAVObject*);
-			REL::Relocation<func_t> func{ RELOCATION_ID(29218, 30071) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(29218, 30071) };
 			return func(a_cell, a_lifetime, a_modelName, a_rotation, a_position, a_scale, a_flags, a_target);
 		}
 		static BSTempEffectParticle* Spawn(TESObjectCELL* a_cell, float a_lifetime, const char* a_modelName, const NiMatrix3& a_normal, const NiPoint3& a_position, float a_scale, std::uint32_t a_flags, NiAVObject* a_target)
 		{
 			using func_t = BSTempEffectParticle* (*)(TESObjectCELL*, float, const char*, const NiMatrix3&, const NiPoint3&, float, std::uint32_t, NiAVObject*);
-			REL::Relocation<func_t> func{ RELOCATION_ID(29219, 30072) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(29219, 30072) };
 			return func(a_cell, a_lifetime, a_modelName, a_normal, a_position, a_scale, a_flags, a_target);
 		}
 

--- a/include/RE/B/BSTempEffectWeaponBlood.h
+++ b/include/RE/B/BSTempEffectWeaponBlood.h
@@ -21,7 +21,7 @@ namespace RE
 		static void ClearEffectForWeapon(NiAVObject* a_weapon3D)
 		{
 			using func_t = decltype(&ClearEffectForWeapon);
-			REL::Relocation<func_t> func{ RELOCATION_ID(29303, 30154) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(29303, 30154) };
 			return func(a_weapon3D);
 		}
 

--- a/include/RE/B/BSThreadEvent.h
+++ b/include/RE/B/BSThreadEvent.h
@@ -7,7 +7,7 @@ namespace RE
 		static void InitSDM()
 		{
 			using func_t = decltype(&BSThreadEvent::InitSDM);
-			REL::Relocation<func_t> func{ RELOCATION_ID(67151, 68449) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(67151, 68449) };
 			return func();
 		}
 	};

--- a/include/RE/B/BSTimer.h
+++ b/include/RE/B/BSTimer.h
@@ -26,7 +26,7 @@ namespace RE
 		void SetGlobalTimeMultiplier(float a_multiplier, bool a_arg2)
 		{
 			using func_t = decltype(&BSTimer::SetGlobalTimeMultiplier);
-			REL::Relocation<func_t> func{ RELOCATION_ID(66988, 68245) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(66988, 68245) };
 			return func(this, a_multiplier, a_arg2);
 		}
 

--- a/include/RE/B/BShkbAnimationGraph.h
+++ b/include/RE/B/BShkbAnimationGraph.h
@@ -79,42 +79,42 @@ namespace RE
 		bool GetGraphVariableBool(const BSFixedString& a_variableName, bool& a_out) const
 		{
 			using func_t = decltype(&BShkbAnimationGraph::GetGraphVariableBool);
-			REL::Relocation<func_t> func{ RELOCATION_ID(62696, 63613) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(62696, 63613) };
 			return func(this, a_variableName, a_out);
 		}
 
 		bool GetGraphVariableFloat(const BSFixedString& a_variableName, float& a_out) const
 		{
 			using func_t = decltype(&BShkbAnimationGraph::GetGraphVariableFloat);
-			REL::Relocation<func_t> func{ RELOCATION_ID(62695, 63614) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(62695, 63614) };
 			return func(this, a_variableName, a_out);
 		}
 
 		bool GetGraphVariableInt(const BSFixedString& a_variableName, int& a_out) const
 		{
 			using func_t = decltype(&BShkbAnimationGraph::GetGraphVariableInt);
-			REL::Relocation<func_t> func{ RELOCATION_ID(62694, 63615) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(62694, 63615) };
 			return func(this, a_variableName, a_out);
 		}
 
 		bool SetGraphVariableBool(const BSFixedString& a_variableName, const bool a_in)
 		{
 			using func_t = decltype(&BShkbAnimationGraph::SetGraphVariableBool);
-			REL::Relocation<func_t> func{ RELOCATION_ID(63609, 62708) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(63609, 62708) };
 			return func(this, a_variableName, a_in);
 		}
 
 		bool SetGraphVariableFloat(const BSFixedString& a_variableName, const float a_in)
 		{
 			using func_t = decltype(&BShkbAnimationGraph::SetGraphVariableFloat);
-			REL::Relocation<func_t> func{ RELOCATION_ID(63608, 62709) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(63608, 62709) };
 			return func(this, a_variableName, a_in);
 		}
 
 		bool SetGraphVariableInt(const BSFixedString& a_variableName, const int a_in)
 		{
 			using func_t = decltype(&BShkbAnimationGraph::SetGraphVariableInt);
-			REL::Relocation<func_t> func{ RELOCATION_ID(63607, 62710) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(63607, 62710) };
 			return func(this, a_variableName, a_in);
 		}
 

--- a/include/RE/B/bhkCharacterController.h
+++ b/include/RE/B/bhkCharacterController.h
@@ -99,14 +99,14 @@ namespace RE
 		static bool IsHurtfulBody(hkpRigidBody* a_body)
 		{
 			using func_t = decltype(&bhkCharacterController::IsHurtfulBody);
-			REL::Relocation<func_t> func{ RELOCATION_ID(76456, 78298) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(76456, 78298) };
 			return func(a_body);
 		}
 
 		void ProcessHurtfulBody(hkpRigidBody* a_body, const hkContactPoint* a_contactPoint)
 		{
 			using func_t = decltype(&bhkCharacterController::ProcessHurtfulBody);
-			REL::Relocation<func_t> func{ RELOCATION_ID(76460, 78302) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(76460, 78302) };
 			func(this, a_body, a_contactPoint);
 		}
 

--- a/include/RE/B/bhkCollisionObject.h
+++ b/include/RE/B/bhkCollisionObject.h
@@ -30,7 +30,7 @@ namespace RE
 		[[nodiscard]] bhkRigidBody* GetRigidBody() const
 		{
 			using func_t = decltype(&bhkCollisionObject::GetRigidBody);
-			REL::Relocation<func_t> func{ RELOCATION_ID(12784, 20014) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(12784, 20014) };
 			return func(this);
 		}
 	};

--- a/include/RE/B/bhkShape.h
+++ b/include/RE/B/bhkShape.h
@@ -33,7 +33,7 @@ namespace RE
 		[[nodiscard]] MATERIAL_ID GetMaterialID(hkpShapeKey a_key) const
 		{
 			using func_t = decltype(&bhkShape::GetMaterialID);
-			REL::Relocation<func_t> func{ RELOCATION_ID(76799, 78676) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(76799, 78676) };
 			return func(this, a_key);
 		}
 

--- a/include/RE/C/CombatMagicCaster.h
+++ b/include/RE/C/CombatMagicCaster.h
@@ -36,14 +36,14 @@ namespace RE
 		bool CheckTargetValid(const CombatController* a_combatController)
 		{
 			using func_t = bool* (*)(CombatMagicCaster*, const CombatController*);
-			REL::Relocation<func_t> func{ RELOCATION_ID(43956, 45348) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(43956, 45348) };
 			return func(this, a_combatController);
 		}
 
 		static bool CheckTargetValid(const CombatController* a_combatController, Actor* a_target, const CombatInventoryItemMagic* a_inventoryItem)
 		{
 			using func_t = bool* (*)(const CombatController*, Actor*, const CombatInventoryItemMagic*);
-			REL::Relocation<func_t> func{ RELOCATION_ID(43952, 45343) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(43952, 45343) };
 			return func(a_combatController, a_target, a_inventoryItem);
 		}
 

--- a/include/RE/C/CraftingMenu.h
+++ b/include/RE/C/CraftingMenu.h
@@ -29,7 +29,7 @@ namespace RE
 		static void QuitMenu()
 		{
 			using func_t = decltype(&CraftingMenu::QuitMenu);
-			REL::Relocation<func_t> func{ RELOCATION_ID(50447, 51352) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(50447, 51352) };
 			return func();
 		}
 

--- a/include/RE/C/CraftingSubMenu.h
+++ b/include/RE/C/CraftingSubMenu.h
@@ -35,7 +35,7 @@ namespace RE
 			void UpdateCraftingInfo(ActorValue a_actorValue)
 			{
 				using func_t = decltype(&CraftingSubMenu::UpdateCraftingInfo);
-				REL::Relocation<func_t> func{ RELOCATION_ID(50461, 51364) };
+				static REL::Relocation<func_t> func{ RELOCATION_ID(50461, 51364) };
 				return func(this, a_actorValue);
 			}
 

--- a/include/RE/D/DialogueItem.h
+++ b/include/RE/D/DialogueItem.h
@@ -63,7 +63,7 @@ namespace RE
 		DialogueItem* Ctor(TESQuest* a_quest, TESTopic* a_topic, TESTopicInfo* a_topicInfo, TESObjectREFR* a_speaker)
 		{
 			using func_t = decltype(&DialogueItem::Ctor);
-			REL::Relocation<func_t> func{ RELOCATION_ID(34413, 35220) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(34413, 35220) };
 			return func(this, a_quest, a_topic, a_topicInfo, a_speaker);
 		}
 	};

--- a/include/RE/F/FixedStrings.h
+++ b/include/RE/F/FixedStrings.h
@@ -10,7 +10,7 @@ namespace RE
 		static FixedStrings* GetSingleton()
 		{
 			using func_t = decltype(&FixedStrings::GetSingleton);
-			REL::Relocation<func_t> func{ RELOCATION_ID(11308, 11437) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(11308, 11437) };
 			return func();
 		}
 

--- a/include/RE/G/GSysAllocPaged.h
+++ b/include/RE/G/GSysAllocPaged.h
@@ -29,14 +29,14 @@ namespace RE
 		bool InitHeapEngine(const void* a_heapDesc) override  // 01
 		{
 			using func_t = decltype(&GSysAllocPaged::InitHeapEngine);
-			REL::Relocation<func_t> func{ RELOCATION_ID(82462, 84557) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(82462, 84557) };
 			return func(this, a_heapDesc);
 		}
 
 		void ShutdownHeapEngine() override  // 02
 		{
 			using func_t = decltype(&GSysAllocPaged::ShutdownHeapEngine);
-			REL::Relocation<func_t> func{ RELOCATION_ID(82464, 84559) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(82464, 84559) };
 			return func(this);
 		}
 

--- a/include/RE/G/GarbageCollector.h
+++ b/include/RE/G/GarbageCollector.h
@@ -58,7 +58,7 @@ namespace RE
 		void Add(TESObjectREFR* a_object, bool a_removeFromCell)
 		{
 			using func_t = decltype(&GarbageCollector::Add);
-			REL::Relocation<func_t> func{ RELOCATION_ID(35492, 36459) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(35492, 36459) };
 			return func(this, a_object, a_removeFromCell);
 		}
 

--- a/include/RE/H/HUDMenu.h
+++ b/include/RE/H/HUDMenu.h
@@ -43,14 +43,14 @@ namespace RE
 		static void FlashMeter(ActorValue a_actorValue)
 		{
 			using func_t = decltype(&HUDMenu::FlashMeter);
-			REL::Relocation<func_t> func{ RELOCATION_ID(51907, 52845) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(51907, 52845) };
 			return func(a_actorValue);
 		}
 
 		static void UpdateCrosshairMagicTarget(bool a_valid)
 		{
 			using func_t = decltype(&HUDMenu::UpdateCrosshairMagicTarget);
-			REL::Relocation<func_t> func{ RELOCATION_ID(50738, 51633) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(50738, 51633) };
 			return func(a_valid);
 		}
 

--- a/include/RE/H/HighProcessData.h
+++ b/include/RE/H/HighProcessData.h
@@ -171,14 +171,14 @@ namespace RE
 		void ClearHeadtrackTarget(HEAD_TRACK_TYPE a_headtrackType, bool a_defaultHold)
 		{
 			using func_t = decltype(&HighProcessData::ClearHeadtrackTarget);
-			REL::Relocation<func_t> func{ RELOCATION_ID(38726, 39756) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(38726, 39756) };
 			return func(this, a_headtrackType, a_defaultHold);
 		}
 
 		void SetHeadtrackTarget(HEAD_TRACK_TYPE a_headtrackType, TESObjectREFR* a_target)
 		{
 			using func_t = decltype(&HighProcessData::SetHeadtrackTarget);
-			REL::Relocation<func_t> func{ RELOCATION_ID(38760, 39783) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(38760, 39783) };
 			return func(this, a_headtrackType, a_target);
 		}
 

--- a/include/RE/H/HitData.h
+++ b/include/RE/H/HitData.h
@@ -44,7 +44,7 @@ namespace RE
 		void Populate(Actor* a_aggressor, Actor* a_target, InventoryEntryData* a_weapon)
 		{
 			using func_t = decltype(&HitData::Populate);
-			REL::Relocation<func_t> func(RELOCATION_ID(42832, 44001));
+			static REL::Relocation<func_t> func(RELOCATION_ID(42832, 44001));
 			return func(this, a_aggressor, a_target, a_weapon);
 		}
 

--- a/include/RE/H/SendHUDMessage.h
+++ b/include/RE/H/SendHUDMessage.h
@@ -7,14 +7,14 @@ namespace RE
 		inline void PopHUDMode(const char* a_hudMode)
 		{
 			using func_t = decltype(&SendHUDMessage::PopHUDMode);
-			REL::Relocation<func_t> func{ RELOCATION_ID(50726, 51621) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(50726, 51621) };
 			return func(a_hudMode);
 		}
 
 		inline void PushHUDMode(const char* a_hudMode)
 		{
 			using func_t = decltype(&SendHUDMessage::PushHUDMode);
-			REL::Relocation<func_t> func{ RELOCATION_ID(50725, 51620) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(50725, 51620) };
 			return func(a_hudMode);
 		}
 	}

--- a/include/RE/H/hkpEntity.h
+++ b/include/RE/H/hkpEntity.h
@@ -80,14 +80,14 @@ namespace RE
 		void AddContactListener(hkpContactListener* a_listener)
 		{
 			using func_t = decltype(&hkpEntity::AddContactListener);
-			REL::Relocation<func_t> func{ RELOCATION_ID(60094, 60844) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(60094, 60844) };
 			return func(this, a_listener);
 		}
 
 		void RemoveContactListener(hkpContactListener* a_listener)
 		{
 			using func_t = decltype(&hkpEntity::RemoveContactListener);
-			REL::Relocation<func_t> func{ RELOCATION_ID(60095, 60845) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(60095, 60845) };
 			return func(this, a_listener);
 		}
 
@@ -125,7 +125,7 @@ namespace RE
 		void Activate()
 		{
 			using func_t = decltype(&hkpEntity::Activate);
-			REL::Relocation<func_t> func{ RELOCATION_ID(60096, 60849) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(60096, 60849) };
 			return func(this);
 		}
 	};

--- a/include/RE/H/hkpWorld.h
+++ b/include/RE/H/hkpWorld.h
@@ -72,21 +72,21 @@ namespace RE
 		inline hkpPhantom* AddPhantom(hkpPhantom* a_phantom)
 		{
 			using func_t = decltype(&hkpWorld::AddPhantom);
-			REL::Relocation<func_t> func{ RELOCATION_ID(60502, 61314) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(60502, 61314) };
 			return func(this, a_phantom);
 		}
 
 		inline void RemovePhantom(hkpPhantom* a_phantom)
 		{
 			using func_t = decltype(&hkpWorld::RemovePhantom);
-			REL::Relocation<func_t> func{ RELOCATION_ID(60504, 61316) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(60504, 61316) };
 			return func(this, a_phantom);
 		}
 
 		inline void CastRay(const hkpWorldRayCastInput& a_input, hkpWorldRayCastOutput& a_output) const
 		{
 			using func_t = decltype(&hkpWorld::CastRay);
-			REL::Relocation<func_t> func{ RELOCATION_ID(60551, 61399) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(60551, 61399) };
 			return func(this, a_input, a_output);
 		}
 

--- a/include/RE/I/ID.h
+++ b/include/RE/I/ID.h
@@ -12,7 +12,7 @@ namespace RE
 			void GenerateFromPath(const char* a_path)
 			{
 				using func_t = decltype(&ID::GenerateFromPath);
-				REL::Relocation<func_t> func{ RELOCATION_ID(68635, 69979) };
+				static REL::Relocation<func_t> func{ RELOCATION_ID(68635, 69979) };
 				return func(this, a_path);
 			}
 

--- a/include/RE/I/ImageSpaceModifierInstanceForm.h
+++ b/include/RE/I/ImageSpaceModifierInstanceForm.h
@@ -22,21 +22,21 @@ namespace RE
 		static ImageSpaceModifierInstanceForm* Trigger(TESImageSpaceModifier* a_imod, float a_strength, NiAVObject* a_target)
 		{
 			using func_t = decltype(&ImageSpaceModifierInstanceForm::Trigger);
-			REL::Relocation<func_t> func{ RELOCATION_ID(18185, 18570) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(18185, 18570) };
 			return func(a_imod, a_strength, a_target);
 		}
 
 		static void Stop(TESImageSpaceModifier* a_imod)
 		{
 			using func_t = decltype(&ImageSpaceModifierInstanceForm::Stop);
-			REL::Relocation<func_t> func{ RELOCATION_ID(18188, 18573) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(18188, 18573) };
 			return func(a_imod);
 		}
 
 		static void StopCrossFade(float a_seconds)
 		{
 			using func_t = decltype(&ImageSpaceModifierInstanceForm::StopCrossFade);
-			REL::Relocation<func_t> func{ RELOCATION_ID(18192, 18577) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(18192, 18577) };
 			return func(a_seconds);
 		}
 

--- a/include/RE/M/MapMenu.h
+++ b/include/RE/M/MapMenu.h
@@ -45,7 +45,7 @@ namespace RE
 		void PlaceMarker()
 		{
 			using func_t = decltype(&MapMenu::PlaceMarker);
-			REL::Relocation<func_t> func{ RELOCATION_ID(52226, 53113) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(52226, 53113) };
 			return func(this);
 		}
 

--- a/include/RE/M/MemoryManager.h
+++ b/include/RE/M/MemoryManager.h
@@ -29,42 +29,42 @@ namespace RE
 		[[nodiscard]] static MemoryManager* GetSingleton()
 		{
 			using func_t = decltype(&MemoryManager::GetSingleton);
-			REL::Relocation<func_t> func{ RELOCATION_ID(11045, 11141) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(11045, 11141) };
 			return func();
 		}
 
 		[[nodiscard]] void* Allocate(std::size_t a_size, std::int32_t a_alignment, bool a_alignmentRequired)
 		{
 			using func_t = decltype(&MemoryManager::Allocate);
-			REL::Relocation<func_t> func{ RELOCATION_ID(66859, 68115) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(66859, 68115) };
 			return func(this, a_size, a_alignment, a_alignmentRequired);
 		}
 
 		void Deallocate(void* a_mem, bool a_alignmentRequired)
 		{
 			using func_t = decltype(&MemoryManager::Deallocate);
-			REL::Relocation<func_t> func{ RELOCATION_ID(66861, 68117) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(66861, 68117) };
 			return func(this, a_mem, a_alignmentRequired);
 		}
 
 		[[nodiscard]] ScrapHeap* GetThreadScrapHeap()
 		{
 			using func_t = decltype(&MemoryManager::GetThreadScrapHeap);
-			REL::Relocation<func_t> func{ RELOCATION_ID(66841, 68088) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(66841, 68088) };
 			return func(this);
 		}
 
 		[[nodiscard]] void* Reallocate(void* a_oldMem, std::size_t a_newSize, std::int32_t a_alignment, bool a_aligned)
 		{
 			using func_t = decltype(&MemoryManager::Reallocate);
-			REL::Relocation<func_t> func{ RELOCATION_ID(66860, 68116) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(66860, 68116) };
 			return func(this, a_oldMem, a_newSize, a_alignment, a_aligned);
 		}
 
 		void RegisterMemoryManager()
 		{
 			using func_t = decltype(&MemoryManager::RegisterMemoryManager);
-			REL::Relocation<func_t> func{ RELOCATION_ID(35199, 36091) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(35199, 36091) };
 			return func(this);
 		}
 

--- a/include/RE/M/MessageBoxData.h
+++ b/include/RE/M/MessageBoxData.h
@@ -19,7 +19,7 @@ namespace RE
 		void QueueMessage()
 		{
 			using func_t = decltype(&MessageBoxData::QueueMessage);
-			REL::Relocation<func_t> func{ RELOCATION_ID(51422, 52271) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(51422, 52271) };
 			return func(this);
 		}
 

--- a/include/RE/N/NiParticleSystem.h
+++ b/include/RE/N/NiParticleSystem.h
@@ -38,7 +38,7 @@ namespace RE
 		void AddModifier(NiPSysModifier* a_modifier)
 		{
 			using func_t = decltype(&NiParticleSystem::AddModifier);
-			REL::Relocation<func_t> func{ RELOCATION_ID(72799, 74499) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(72799, 74499) };
 			return func(this, a_modifier);
 		}
 

--- a/include/RE/N/NiPointLight.h
+++ b/include/RE/N/NiPointLight.h
@@ -34,7 +34,7 @@ namespace RE
 		void SetLightAttenuation(float a_radius)
 		{
 			using func_t = decltype(&NiPointLight::SetLightAttenuation);
-			REL::Relocation<func_t> func{ RELOCATION_ID(17224, 17626) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(17224, 17626) };
 			return func(this, a_radius);
 		}
 
@@ -47,7 +47,7 @@ namespace RE
 		NiPointLight* Ctor()
 		{
 			using func_t = decltype(&NiPointLight::Ctor);
-			REL::Relocation<func_t> func{ RELOCATION_ID(69583, 70967) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(69583, 70967) };
 			return func(this);
 		}
 	};

--- a/include/RE/P/PermanentMagicFunctor.h
+++ b/include/RE/P/PermanentMagicFunctor.h
@@ -24,7 +24,7 @@ namespace RE
 		BSContainer::ForEachResult operator()(MagicItem* a_spell)
 		{
 			using func_t = decltype(&PermanentMagicFunctor::operator());
-			REL::Relocation<func_t> func{ RELOCATION_ID(33684, 34464) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(33684, 34464) };
 			return func(this, a_spell);
 		}
 

--- a/include/RE/P/Precipitation.h
+++ b/include/RE/P/Precipitation.h
@@ -41,14 +41,14 @@ namespace RE
 		void SetupMask()
 		{
 			using func_t = decltype(&Precipitation::SetupMask);
-			REL::Relocation<func_t> func{ RELOCATION_ID(25641, 26183) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(25641, 26183) };
 			func(this);
 		}
 
 		void RenderMask(BSParticleShaderRainEmitter* a_emitter)
 		{
 			using func_t = decltype(&Precipitation::RenderMask);
-			REL::Relocation<func_t> func{ RELOCATION_ID(25642, 26184) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(25642, 26184) };
 			func(this, a_emitter);
 		}
 

--- a/include/RE/RTTI.h
+++ b/include/RE/RTTI.h
@@ -127,7 +127,7 @@ namespace RE
 	inline void* RTDynamicCast(void* a_inptr, std::int32_t a_vfDelta, void* a_srcType, void* a_targetType, std::int32_t a_isReference)
 	{
 		using func_t = decltype(&RTDynamicCast);
-		REL::Relocation<func_t> func{ RELOCATION_ID(102238, 109689) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(102238, 109689) };
 		return func(a_inptr, a_vfDelta, a_srcType, a_targetType, a_isReference);
 	}
 

--- a/include/RE/S/ScreenSplatter.h
+++ b/include/RE/S/ScreenSplatter.h
@@ -22,7 +22,7 @@ namespace RE
 		void Clear()
 		{
 			using func_t = decltype(&ScreenSplatter::Clear);
-			REL::Relocation<func_t> func{ RELOCATION_ID(16175, 16407) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(16175, 16407) };
 			return func(this);
 		}
 

--- a/include/RE/S/Script.h
+++ b/include/RE/S/Script.h
@@ -55,7 +55,7 @@ namespace RE
 		{
 			static_assert((std::is_pointer_v<Args> && ...), "arguments must all be pointers");
 			using func_t = bool(const SCRIPT_PARAMETER*, SCRIPT_FUNCTION::ScriptData*, std::uint32_t&, TESObjectREFR*, TESObjectREFR*, Script*, ScriptLocals*, ...);
-			REL::Relocation<func_t> func{ RELOCATION_ID(21425, 21910) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(21425, 21910) };
 			return func(a_paramInfo, a_scriptData, a_opcodeOffsetPtr, a_thisObj, a_containingObj, a_scriptObj, a_locals, a_args...);
 		}
 

--- a/include/RE/S/ShadowSceneNode.h
+++ b/include/RE/S/ShadowSceneNode.h
@@ -47,7 +47,7 @@ namespace RE
 		BSLight* AddLight(NiLight* a_light, const LIGHT_CREATE_PARAMS& a_params)
 		{
 			using func_t = decltype(&ShadowSceneNode::AddLight);
-			REL::Relocation<func_t> func{ RELOCATION_ID(99692, 106326) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(99692, 106326) };
 			return func(this, a_light, a_params);
 		}
 

--- a/include/RE/S/SleepWaitMenu.h
+++ b/include/RE/S/SleepWaitMenu.h
@@ -24,7 +24,7 @@ namespace RE
 		static void ToggleOpenSleepWaitMenu(bool a_sleeping)
 		{
 			using func_t = decltype(&SleepWaitMenu::ToggleOpenSleepWaitMenu);
-			REL::Relocation<func_t> func{ RELOCATION_ID(51618, 52490) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(51618, 52490) };
 			return func(a_sleeping);
 		}
 

--- a/include/RE/S/SubtitleManager.h
+++ b/include/RE/S/SubtitleManager.h
@@ -30,7 +30,7 @@ namespace RE
 		void KillSubtitles()
 		{
 			using func_t = decltype(&SubtitleManager ::KillSubtitles);
-			REL::Relocation<func_t> func{ RELOCATION_ID(51755, 52628) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(51755, 52628) };
 			return func(this);
 		}
 

--- a/include/RE/T/TESActionData.h
+++ b/include/RE/T/TESActionData.h
@@ -35,8 +35,8 @@ namespace RE
 		TESActionData* Ctor()
 		{
 			using func_t = decltype(&TESActionData::Ctor);
-			REL::Relocation<func_t> func{ RELOCATION_ID(15916, 41558) };
-			TESActionData*          tesActionData = func(this);
+			static REL::Relocation<func_t> func{ RELOCATION_ID(15916, 41558) };
+			TESActionData*                 tesActionData = func(this);
 			stl::emplace_vtable<TESActionData>(tesActionData);
 			return tesActionData;
 		}

--- a/include/RE/T/TESActorBaseData.h
+++ b/include/RE/T/TESActorBaseData.h
@@ -117,7 +117,7 @@ namespace RE
 		[[nodiscard]] std::uint16_t GetLevel() const
 		{
 			using func_t = decltype(&TESActorBaseData::GetLevel);
-			REL::Relocation<func_t> func{ RELOCATION_ID(14262, 14384) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(14262, 14384) };
 			return func(this);
 		}
 

--- a/include/RE/T/TESForm.h
+++ b/include/RE/T/TESForm.h
@@ -183,7 +183,7 @@ namespace RE
 		static void AddCompileIndex(FormID& a_id, TESFile* a_file)
 		{
 			using func_t = decltype(&TESForm::AddCompileIndex);
-			REL::Relocation<func_t> func{ RELOCATION_ID(14509, 14667) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(14509, 14667) };
 			func(a_id, a_file);
 		}
 

--- a/include/RE/T/TESFullName.h
+++ b/include/RE/T/TESFullName.h
@@ -24,7 +24,7 @@ namespace RE
 		void SetFullName(const char* a_name)
 		{
 			using func_t = decltype(&TESFullName::SetFullName);
-			REL::Relocation<func_t> func{ RELOCATION_ID(22318, 22791) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(22318, 22791) };
 			func(this, a_name);
 		}
 

--- a/include/RE/T/TESIdleForm.h
+++ b/include/RE/T/TESIdleForm.h
@@ -63,7 +63,7 @@ namespace RE
 		bool CheckConditions(Actor* a_actor, TESObjectREFR* a_target, bool a_checkParentIdle)
 		{
 			using func_t = decltype(&TESIdleForm::CheckConditions);
-			REL::Relocation<func_t> func{ RELOCATION_ID(24069, 24572) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(24069, 24572) };
 			return func(this, a_actor, a_target, a_checkParentIdle);
 		}
 

--- a/include/RE/T/TESImageSpaceModifier.h
+++ b/include/RE/T/TESImageSpaceModifier.h
@@ -195,7 +195,7 @@ namespace RE
 		ImageSpaceModifierInstanceForm* TriggerIfNotActive(float a_strength, NiAVObject* a_target)
 		{
 			using func_t = decltype(&TESImageSpaceModifier::TriggerIfNotActive);
-			REL::Relocation<func_t> func{ RELOCATION_ID(18187, 18572) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(18187, 18572) };
 			return func(this, a_strength, a_target);
 		}
 

--- a/include/RE/T/TESObjectDOOR.h
+++ b/include/RE/T/TESObjectDOOR.h
@@ -70,7 +70,7 @@ namespace RE
 		static void LinkRandomTeleportDoors(TESObjectREFR* a_door, TESObjectREFR* a_linkedDoor)
 		{
 			using func_t = decltype(&TESObjectDOOR::LinkRandomTeleportDoors);
-			REL::Relocation<func_t> func{ RELOCATION_ID(17539, 17944) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(17539, 17944) };
 			return func(a_door, a_linkedDoor);
 		}
 

--- a/include/RE/T/TESObjectLIGH.h
+++ b/include/RE/T/TESObjectLIGH.h
@@ -105,7 +105,7 @@ namespace RE
 		NiLight* GenDynamic(RE::TESObjectREFR* a_ref, RE::NiNode* a_node, char a_forceDynamic, char a_useLightRadius, char a_affectRefOnly)
 		{
 			using func_t = decltype(&TESObjectLIGH::GenDynamic);
-			REL::Relocation<func_t> func{ RELOCATION_ID(17208, 17610) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(17208, 17610) };
 			return func(this, a_ref, a_node, a_forceDynamic, a_useLightRadius, a_affectRefOnly);
 		}
 

--- a/include/RE/T/TESWaterSystem.h
+++ b/include/RE/T/TESWaterSystem.h
@@ -35,7 +35,7 @@ namespace RE
 		void AddRipple(const NiPoint3& a_pos, float a_scale)
 		{
 			using func_t = decltype(&TESWaterSystem::AddRipple);
-			REL::Relocation<func_t> func{ RELOCATION_ID(31410, 32217) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(31410, 32217) };
 			return func(this, a_pos, a_scale);
 		}
 

--- a/include/RE/T/TutorialMenu.h
+++ b/include/RE/T/TutorialMenu.h
@@ -23,7 +23,7 @@ namespace RE
 		static void OpenTutorialMenu(DEFAULT_OBJECT a_tutorial)
 		{
 			using func_t = decltype(&TutorialMenu::OpenTutorialMenu);
-			REL::Relocation<func_t> func{ RELOCATION_ID(51818, 52692) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(51818, 52692) };
 			return func(a_tutorial);
 		}
 

--- a/include/RE/V/VATS.h
+++ b/include/RE/V/VATS.h
@@ -54,7 +54,7 @@ namespace RE
 		void SetMagicTimeSlowdown(float a_magicTimeSlowdown, float a_playerMagicTimeSlowdown)
 		{
 			using func_t = decltype(&VATS::SetMagicTimeSlowdown);
-			REL::Relocation<func_t> func{ RELOCATION_ID(43103, 44300) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(43103, 44300) };
 			return func(this, a_magicTimeSlowdown, a_playerMagicTimeSlowdown);
 		}
 

--- a/src/RE/A/AIFormulas.cpp
+++ b/src/RE/A/AIFormulas.cpp
@@ -9,14 +9,14 @@ namespace RE
 		std::int32_t ComputePickpocketSuccess(float a_thiefSkill, float a_targetSkill, std::uint32_t a_valueStolen, float a_weightStolen, Actor* a_thief, Actor* a_target, bool a_isDetected, TESForm* a_itemPickpocketing)
 		{
 			using func_t = decltype(ComputePickpocketSuccess);
-			REL::Relocation<func_t> func{ RELOCATION_ID(25822, 26379) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(25822, 26379) };
 			return func(a_thiefSkill, a_targetSkill, a_valueStolen, a_weightStolen, a_thief, a_target, a_isDetected, a_itemPickpocketing);
 		}
 
 		std::int32_t GetSoundLevelValue(SOUND_LEVEL a_soundLevel)
 		{
 			using func_t = decltype(GetSoundLevelValue);
-			REL::Relocation<func_t> func{ RELOCATION_ID(25814, 26367) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(25814, 26367) };
 			return func(a_soundLevel);
 		}
 	}

--- a/src/RE/A/AIProcess.cpp
+++ b/src/RE/A/AIProcess.cpp
@@ -20,7 +20,7 @@ namespace RE
 	void AIProcess::ClearMuzzleFlashes()
 	{
 		using func_t = decltype(&AIProcess::ClearMuzzleFlashes);
-		REL::Relocation<func_t> func{ RELOCATION_ID(38495, 39504) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(38495, 39504) };
 		return func(this);
 	}
 
@@ -57,7 +57,7 @@ namespace RE
 	ObjectRefHandle AIProcess::GetHeadtrackTarget() const
 	{
 		using func_t = decltype(&AIProcess::GetHeadtrackTarget);
-		REL::Relocation<func_t> func{ RELOCATION_ID(38483, 39484) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(38483, 39484) };
 		return func(this);
 	}
 
@@ -197,7 +197,7 @@ namespace RE
 	void AIProcess::KnockExplosion(Actor* a_actor, const NiPoint3& a_location, float a_magnitude)
 	{
 		using func_t = decltype(&AIProcess::KnockExplosion);
-		REL::Relocation<func_t> func{ RELOCATION_ID(38858, 39895) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(38858, 39895) };
 		return func(this, a_actor, a_location, a_magnitude);
 	}
 
@@ -209,7 +209,7 @@ namespace RE
 	void AIProcess::SetActorsDetectionEvent(Actor* a_actor, const NiPoint3& a_location, std::int32_t a_soundLevel, TESObjectREFR* a_ref)
 	{
 		using func_t = decltype(&AIProcess::SetActorsDetectionEvent);
-		REL::Relocation<func_t> func{ RELOCATION_ID(38311, 39286) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(38311, 39286) };
 		return func(this, a_actor, a_location, a_soundLevel, a_ref);
 	}
 
@@ -230,7 +230,7 @@ namespace RE
 	void AIProcess::SetHeadtrackTarget(Actor* a_owner, NiPoint3& a_targetPosition)
 	{
 		using func_t = decltype(&AIProcess::SetHeadtrackTarget);
-		REL::Relocation<func_t> func{ RELOCATION_ID(38850, 39887) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(38850, 39887) };
 		return func(this, a_owner, a_targetPosition);
 	}
 
@@ -244,14 +244,14 @@ namespace RE
 	bool AIProcess::SetupSpecialIdle(Actor* a_actor, DEFAULT_OBJECT a_action, TESIdleForm* a_idle, bool a_arg5, bool a_arg6, TESObjectREFR* a_target)
 	{
 		using func_t = decltype(&AIProcess::SetupSpecialIdle);
-		REL::Relocation<func_t> func{ RELOCATION_ID(38290, 39256) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(38290, 39256) };
 		return func(this, a_actor, a_action, a_idle, a_arg5, a_arg6, a_target);
 	}
 
 	void AIProcess::StopCurrentIdle(Actor* a_actor, bool a_forceIdleStop)
 	{
 		using func_t = decltype(&AIProcess::StopCurrentIdle);
-		REL::Relocation<func_t> func{ RELOCATION_ID(38291, 39257) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(38291, 39257) };
 		return func(this, a_actor, a_forceIdleStop);
 	}
 
@@ -268,7 +268,7 @@ namespace RE
 	void AIProcess::Update3DModel_Impl(Actor* a_actor)
 	{
 		using func_t = decltype(&AIProcess::Update3DModel_Impl);
-		REL::Relocation<func_t> func{ Offset::AIProcess::Update3DModel };
+		static REL::Relocation<func_t> func{ Offset::AIProcess::Update3DModel };
 		return func(this, a_actor);
 	}
 

--- a/src/RE/A/ActiveEffect.cpp
+++ b/src/RE/A/ActiveEffect.cpp
@@ -8,7 +8,7 @@ namespace RE
 	void ActiveEffect::Dispel(bool a_force)
 	{
 		using func_t = decltype(&ActiveEffect::Dispel);
-		REL::Relocation<func_t> func{ RELOCATION_ID(33286, 34061) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(33286, 34061) };
 		return func(this, a_force);
 	}
 
@@ -48,7 +48,7 @@ namespace RE
 	float ActiveEffect::GetMagnitude() const
 	{
 		using func_t = decltype(&ActiveEffect::GetMagnitude);
-		REL::Relocation<func_t> func{ RELOCATION_ID(33282, 34057) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(33282, 34057) };
 		return func(this);
 	}
 }

--- a/src/RE/A/ActiveEffectFactory.cpp
+++ b/src/RE/A/ActiveEffectFactory.cpp
@@ -7,7 +7,7 @@ namespace RE
 		bool CheckCast(MagicCaster* a_caster, MagicItem* a_spell, Effect* a_effect, MagicSystem::CannotCastReason& a_reason)
 		{
 			using func_t = decltype(&ActiveEffectFactory::CheckCast);
-			REL::Relocation<func_t> func{ RELOCATION_ID(33716, 34500) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(33716, 34500) };
 			return func(a_caster, a_spell, a_effect, a_reason);
 		}
 	}

--- a/src/RE/A/Actor.cpp
+++ b/src/RE/A/Actor.cpp
@@ -72,21 +72,21 @@ namespace RE
 	void Actor::AddCastPower(SpellItem* a_power)
 	{
 		using func_t = decltype(&Actor::AddCastPower);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37787, 38736) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37787, 38736) };
 		return func(this, a_power);
 	}
 
 	bool Actor::AddSpell(SpellItem* a_spell)
 	{
 		using func_t = decltype(&Actor::AddSpell);
-		REL::Relocation<func_t> func{ Offset::Actor::AddSpell };
+		static REL::Relocation<func_t> func{ Offset::Actor::AddSpell };
 		return func(this, a_spell);
 	}
 
 	void Actor::AddToFaction(TESFaction* a_faction, std::int8_t a_rank)
 	{
 		using func_t = decltype(&Actor::AddToFaction);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36678, 37686) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36678, 37686) };
 		return func(this, a_faction, a_rank);
 	}
 
@@ -113,14 +113,14 @@ namespace RE
 	void Actor::CastPermanentMagic(bool a_wornItemEnchantments, bool a_baseSpells, bool a_raceSpells, bool a_everyActorAbility)
 	{
 		using func_t = decltype(&Actor::CastPermanentMagic);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37804, 38753) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37804, 38753) };
 		return func(this, a_wornItemEnchantments, a_baseSpells, a_raceSpells, a_everyActorAbility);
 	}
 
 	bool Actor::CanAttackActor(Actor* a_actor)
 	{
 		using func_t = decltype(&Actor::CanAttackActor);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36532, 37532) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36532, 37532) };
 		return func(this, a_actor);
 	}
 
@@ -158,7 +158,7 @@ namespace RE
 	bool Actor::CanUseIdle(TESIdleForm* a_idle) const
 	{
 		using func_t = decltype(&Actor::CanUseIdle);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36224, 37205) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36224, 37205) };
 		return func(this, a_idle);
 	}
 
@@ -190,35 +190,35 @@ namespace RE
 	bool Actor::Decapitate()
 	{
 		using func_t = decltype(&Actor::Decapitate);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36631, 37639) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36631, 37639) };
 		return func(this);
 	}
 
 	void Actor::DeselectSpell(SpellItem* a_spell)
 	{
 		using func_t = decltype(&Actor::DeselectSpell);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37820, 38769) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37820, 38769) };
 		return func(this, a_spell);
 	}
 
 	void Actor::DispelAlteredStates(EffectArchetype a_exception)
 	{
 		using func_t = decltype(&Actor::DispelAlteredStates);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37864, 38819) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37864, 38819) };
 		return func(this, a_exception);
 	}
 
 	void Actor::DispelWornItemEnchantments()
 	{
 		using func_t = decltype(&Actor::DispelWornItemEnchantments);
-		REL::Relocation<func_t> func{ Offset::Actor::DispelWornItemEnchantments };
+		static REL::Relocation<func_t> func{ Offset::Actor::DispelWornItemEnchantments };
 		return func(this);
 	}
 
 	void Actor::DoReset3D(bool a_updateWeight)
 	{
 		using func_t = decltype(&Actor::DoReset3D);
-		REL::Relocation<func_t> func{ Offset::Actor::DoReset3D };
+		static REL::Relocation<func_t> func{ Offset::Actor::DoReset3D };
 		return func(this, a_updateWeight);
 	}
 
@@ -237,14 +237,14 @@ namespace RE
 	void Actor::EndInterruptPackage(bool a_skipDialogue)
 	{
 		using func_t = decltype(&Actor::EndInterruptPackage);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36475, 37474) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36475, 37474) };
 		return func(this, a_skipDialogue);
 	}
 
 	void Actor::EvaluatePackage(bool a_immediate, bool a_resetAI)
 	{
 		using func_t = decltype(&Actor::EvaluatePackage);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36407, 37401) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36407, 37401) };
 		return func(this, a_immediate, a_resetAI);
 	}
 
@@ -263,7 +263,7 @@ namespace RE
 	float Actor::GetActorValueModifier(ACTOR_VALUE_MODIFIER a_modifier, ActorValue a_value) const
 	{
 		using func_t = decltype(&Actor::GetActorValueModifier);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37524, 38469) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37524, 38469) };
 		return func(this, a_modifier, a_value);
 	}
 
@@ -322,7 +322,7 @@ namespace RE
 	uint32_t Actor::GetCollisionFilterInfo(uint32_t& a_outCollisionFilterInfo)
 	{
 		using func_t = decltype(&Actor::GetCollisionFilterInfo);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36559, 37560) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36559, 37560) };
 		return func(this, a_outCollisionFilterInfo);
 	}
 
@@ -422,7 +422,7 @@ namespace RE
 	std::int32_t Actor::GetFactionRank(TESFaction* a_faction, bool a_isPlayer)
 	{
 		using func_t = decltype(&Actor::GetFactionRank);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36668, 37676) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36668, 37676) };
 		return func(this, a_faction, a_isPlayer);
 	}
 
@@ -493,7 +493,7 @@ namespace RE
 	std::uint16_t Actor::GetLevel() const
 	{
 		using func_t = decltype(&Actor::GetLevel);
-		REL::Relocation<func_t> func{ Offset::Actor::GetLevel };
+		static REL::Relocation<func_t> func{ Offset::Actor::GetLevel };
 		return func(this);
 	}
 
@@ -505,21 +505,21 @@ namespace RE
 	bool Actor::GetMount(NiPointer<Actor>& a_outMount)
 	{
 		using func_t = decltype(&Actor::GetMount);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37757, 38702) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37757, 38702) };
 		return func(this, a_outMount);
 	}
 
 	double Actor::GetMoveDirectionRelativeToFacing()
 	{
 		using func_t = decltype(&Actor::GetMoveDirectionRelativeToFacing);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36935, 37960) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36935, 37960) };
 		return func(this);
 	}
 
 	bool Actor::GetMountedBy(NiPointer<Actor>& a_outRider)
 	{
 		using func_t = decltype(&Actor::GetMountedBy);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37758, 38703) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37758, 38703) };
 		return func(this, a_outRider);
 	}
 
@@ -553,7 +553,7 @@ namespace RE
 	bool Actor::GetRider(NiPointer<Actor>& a_outRider)
 	{
 		using func_t = decltype(&Actor::GetRider);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37758, 38703) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37758, 38703) };
 		return func(this, a_outRider);
 	}
 
@@ -578,14 +578,14 @@ namespace RE
 	SOUL_LEVEL Actor::GetSoulSize() const
 	{
 		using func_t = decltype(&Actor::GetSoulSize);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37862, 38817) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37862, 38817) };
 		return func(this);
 	}
 
 	float Actor::GetTotalCarryWeight()
 	{
 		using func_t = decltype(&Actor::GetTotalCarryWeight);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36456, 37452) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36456, 37452) };
 		return func(this);
 	}
 
@@ -608,14 +608,14 @@ namespace RE
 	float Actor::GetVoiceRecoveryTime()
 	{
 		using func_t = decltype(&Actor::GetVoiceRecoveryTime);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37854, 38808) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37854, 38808) };
 		return func(this);
 	}
 
 	float Actor::GetWarmthRating() const
 	{
 		using func_t = decltype(&Actor::GetWarmthRating);
-		REL::Relocation<func_t> func{ RELOCATION_ID(25834, 26394) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(25834, 26394) };
 		return func(this);
 	}
 
@@ -665,56 +665,56 @@ namespace RE
 	bool Actor::HasLineOfSight(TESObjectREFR* a_ref, bool& a_arg2)
 	{
 		using func_t = decltype(&Actor::HasLineOfSight);
-		REL::Relocation<func_t> func{ RELOCATION_ID(53029, 53829) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(53029, 53829) };
 		return func(this, a_ref, a_arg2);
 	}
 
 	bool Actor::HasOutfitItems(BGSOutfit* a_outfit)
 	{
 		using func_t = decltype(&Actor::HasOutfitItems);
-		REL::Relocation<func_t> func{ RELOCATION_ID(19265, 19691) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19265, 19691) };
 		return func(this, a_outfit);
 	}
 
 	bool Actor::HasPerk(BGSPerk* a_perk) const
 	{
 		using func_t = decltype(&Actor::HasPerk);
-		REL::Relocation<func_t> func{ Offset::Actor::HasPerk };
+		static REL::Relocation<func_t> func{ Offset::Actor::HasPerk };
 		return func(this, a_perk);
 	}
 
 	bool Actor::HasShout(TESShout* a_shout) const
 	{
 		using func_t = decltype(&Actor::HasShout);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37829, 38783) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37829, 38783) };
 		return func(this, a_shout);
 	}
 
 	bool Actor::HasSpell(SpellItem* a_spell) const
 	{
 		using func_t = decltype(&Actor::HasSpell);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37828, 38782) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37828, 38782) };
 		return func(this, a_spell);
 	}
 
 	void Actor::InitiateDoNothingPackage()
 	{
 		using func_t = decltype(&Actor::InitiateDoNothingPackage);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36408, 37402) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36408, 37402) };
 		return func(this);
 	}
 
 	void Actor::InterruptCast(bool a_restoreMagicka) const
 	{
 		using func_t = decltype(&Actor::InterruptCast);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37808, 38757) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37808, 38757) };
 		return func(this, a_restoreMagicka);
 	}
 
 	bool Actor::IsAttacking() const
 	{
 		using func_t = decltype(&Actor::IsAttacking);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37637, 38590) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37637, 38590) };
 		return func(this);
 	}
 
@@ -748,14 +748,14 @@ namespace RE
 	bool Actor::IsBlocking() const
 	{
 		using func_t = decltype(&Actor::IsBlocking);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36927, 37952) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36927, 37952) };
 		return func(this);
 	}
 
 	bool Actor::IsCasting(MagicItem* a_spell) const
 	{
 		using func_t = decltype(&Actor::IsCasting);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37810, 38759) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37810, 38759) };
 		return func(this, a_spell);
 	}
 
@@ -767,7 +767,7 @@ namespace RE
 	bool Actor::IsCurrentShout(SpellItem* a_power)
 	{
 		using func_t = decltype(&Actor::IsCurrentShout);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37858, 38812) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37858, 38812) };
 		return func(this, a_power);
 	}
 
@@ -803,7 +803,7 @@ namespace RE
 	bool Actor::IsGhost() const
 	{
 		using func_t = decltype(&Actor::IsGhost);
-		REL::Relocation<func_t> func{ Offset::Actor::GetGhost };
+		static REL::Relocation<func_t> func{ Offset::Actor::GetGhost };
 		return func(this);
 	}
 
@@ -815,49 +815,49 @@ namespace RE
 	bool Actor::IsHostileToActor(Actor* a_actor)
 	{
 		using func_t = decltype(&Actor::IsHostileToActor);
-		REL::Relocation<func_t> func{ Offset::Actor::GetHostileToActor };
+		static REL::Relocation<func_t> func{ Offset::Actor::GetHostileToActor };
 		return func(this, a_actor);
 	}
 
 	bool Actor::IsInCastPowerList(SpellItem* a_power)
 	{
 		using func_t = decltype(&Actor::IsInCastPowerList);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37793, 38742) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37793, 38742) };
 		return func(this, a_power);
 	}
 
 	bool Actor::IsInMidair() const
 	{
 		using func_t = decltype(&Actor::IsInMidair);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36259, 37243) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36259, 37243) };
 		return func(this);
 	}
 
 	bool Actor::IsInRagdollState() const
 	{
 		using func_t = decltype(&Actor::IsInRagdollState);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36492, 37491) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36492, 37491) };
 		return func(this);
 	}
 
 	bool Actor::IsLeveled() const
 	{
 		using func_t = decltype(&Actor::IsLeveled);
-		REL::Relocation<func_t> func{ RELOCATION_ID(19824, 20229) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19824, 20229) };
 		return func(this);
 	}
 
 	bool Actor::IsLimbGone(std::uint32_t a_limb)
 	{
 		using func_t = decltype(&Actor::IsLimbGone);
-		REL::Relocation<func_t> func{ RELOCATION_ID(19338, 19765) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19338, 19765) };
 		return func(this, a_limb);
 	}
 
 	bool Actor::IsMoving() const
 	{
 		using func_t = decltype(&Actor::IsMoving);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36928, 37953) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36928, 37953) };
 		return func(this);
 	}
 
@@ -869,7 +869,7 @@ namespace RE
 	bool Actor::IsOverEncumbered() const
 	{
 		using func_t = decltype(&Actor::IsOverEncumbered);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36457, 37453) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36457, 37453) };
 		return func(this);
 	}
 
@@ -886,7 +886,7 @@ namespace RE
 	bool Actor::IsRunning() const
 	{
 		using func_t = decltype(&Actor::IsRunning);
-		REL::Relocation<func_t> func{ Offset::Actor::IsRunning };
+		static REL::Relocation<func_t> func{ Offset::Actor::IsRunning };
 		return func(this);
 	}
 
@@ -920,21 +920,21 @@ namespace RE
 	void Actor::KillImmediate()
 	{
 		using func_t = decltype(&Actor::KillImmediate);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36723, 37735) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36723, 37735) };
 		return func(this);
 	}
 
 	void Actor::PlayASound(BSSoundHandle& a_result, FormID a_formID, bool a_arg3, std::uint32_t a_flags)
 	{
 		using func_t = decltype(&Actor::PlayASound);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36730, 37743) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36730, 37743) };
 		return func(this, a_result, a_formID, a_arg3, a_flags);
 	}
 
 	void Actor::ProcessVATSAttack(MagicCaster* a_caster, bool a_hasTargetAnim, TESObjectREFR* a_target, bool a_leftHand)
 	{
 		using func_t = decltype(&Actor::ProcessVATSAttack);
-		REL::Relocation<func_t> func{ RELOCATION_ID(40230, 41233) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(40230, 41233) };
 		return func(this, a_caster, a_hasTargetAnim, a_target, a_leftHand);
 	}
 
@@ -963,7 +963,7 @@ namespace RE
 	void Actor::RemoveCastScroll(SpellItem* a_spell, MagicSystem::CastingSource a_source)
 	{
 		using func_t = decltype(&Actor::RemoveCastScroll);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37798, 38747) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37798, 38747) };
 		return func(this, a_spell, a_source);
 	}
 
@@ -975,21 +975,21 @@ namespace RE
 	void Actor::RemoveFromFaction(RE::TESFaction* a_faction)
 	{
 		using func_t = decltype(&Actor::RemoveFromFaction);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36680, 37688) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36680, 37688) };
 		return func(this, a_faction);
 	}
 
 	bool Actor::RemoveSpell(SpellItem* a_spell)
 	{
 		using func_t = decltype(&Actor::RemoveSpell);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37772, 38717) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37772, 38717) };
 		return func(this, a_spell);
 	}
 
 	std::int32_t Actor::RequestDetectionLevel(Actor* a_target, DETECTION_PRIORITY a_priority)
 	{
 		using func_t = decltype(&Actor::RequestDetectionLevel);
-		REL::Relocation<func_t> func{ Offset::Actor::RequestDetectionLevel };
+		static REL::Relocation<func_t> func{ Offset::Actor::RequestDetectionLevel };
 		return func(this, a_target, a_priority);
 	}
 
@@ -1011,21 +1011,21 @@ namespace RE
 	void Actor::SetHeading(float a_angle)
 	{
 		using func_t = decltype(&Actor::SetHeading);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36248, 37230) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36248, 37230) };
 		return func(this, a_angle);
 	}
 
 	void Actor::SetLifeState(ACTOR_LIFE_STATE a_lifeState)
 	{
 		using func_t = decltype(&Actor::SetLifeState);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36604, 37612) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36604, 37612) };
 		return func(this, a_lifeState);
 	}
 
 	void Actor::SetLooking(float a_angle)
 	{
 		using func_t = decltype(&Actor::SetLooking);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36602, 37610) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36602, 37610) };
 		return func(this, a_angle);
 	}
 
@@ -1047,7 +1047,7 @@ namespace RE
 	void Actor::StealAlarm(TESObjectREFR* a_ref, TESForm* a_object, std::int32_t a_num, std::int32_t a_total, TESForm* a_owner, bool a_allowWarning)
 	{
 		using func_t = decltype(&Actor::StealAlarm);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36427, 37422) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36427, 37422) };
 		return func(this, a_ref, a_object, a_num, a_total, a_owner, a_allowWarning);
 	}
 
@@ -1063,42 +1063,42 @@ namespace RE
 	void Actor::StopInteractingQuick(bool a_unk02)
 	{
 		using func_t = decltype(&Actor::StopInteractingQuick);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37752, 38697) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37752, 38697) };
 		return func(this, a_unk02);
 	}
 
 	void Actor::StopMoving(float a_delta)
 	{
 		using func_t = decltype(&Actor::StopMoving);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36801, 37817) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36801, 37817) };
 		return func(this, a_delta);
 	}
 
 	void Actor::SwitchRace(TESRace* a_race, bool a_player)
 	{
 		using func_t = decltype(&Actor::SwitchRace);
-		REL::Relocation<func_t> func{ Offset::Actor::SwitchRace };
+		static REL::Relocation<func_t> func{ Offset::Actor::SwitchRace };
 		return func(this, a_race, a_player);
 	}
 
 	void Actor::TrespassAlarm(TESObjectREFR* a_ref, TESForm* a_ownership, std::int32_t a_crime)
 	{
 		using func_t = decltype(&Actor::TrespassAlarm);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36432, 37427) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36432, 37427) };
 		return func(this, a_ref, a_ownership, a_crime);
 	}
 
 	void Actor::UpdateArmorAbility(TESForm* a_armor, ExtraDataList* a_extraData)
 	{
 		using func_t = decltype(&Actor::UpdateArmorAbility);
-		REL::Relocation<func_t> func{ Offset::Actor::UpdateArmorAbility };
+		static REL::Relocation<func_t> func{ Offset::Actor::UpdateArmorAbility };
 		return func(this, a_armor, a_extraData);
 	}
 
 	void Actor::UpdateAwakeSound(NiAVObject* a_obj3D)
 	{
 		using func_t = decltype(&Actor::UpdateAwakeSound);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36943, 37968) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36943, 37968) };
 		return func(this, a_obj3D);
 	}
 
@@ -1159,7 +1159,7 @@ namespace RE
 	void Actor::UpdateWeaponAbility(TESForm* a_weapon, ExtraDataList* a_extraData, bool a_leftHand)
 	{
 		using func_t = decltype(&Actor::UpdateWeaponAbility);
-		REL::Relocation<func_t> func{ Offset::Actor::UpdateWeaponAbility };
+		static REL::Relocation<func_t> func{ Offset::Actor::UpdateWeaponAbility };
 		return func(this, a_weapon, a_extraData, a_leftHand);
 	}
 
@@ -1214,7 +1214,7 @@ namespace RE
 	void Actor::VisitSpells(ForEachSpellVisitor& a_visitor)
 	{
 		using func_t = decltype(&Actor::VisitSpells);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37827, 38781) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37827, 38781) };
 		return func(this, a_visitor);
 	}
 
@@ -1241,14 +1241,14 @@ namespace RE
 	void Actor::CalculateCurrentVendorFaction() const
 	{
 		using func_t = decltype(&Actor::CalculateCurrentVendorFaction);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36392, 37383) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36392, 37383) };
 		return func(this);
 	}
 
 	float Actor::CalcEquippedWeight()
 	{
 		using func_t = decltype(&Actor::CalcEquippedWeight);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37016, 38044) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37016, 38044) };
 		return func(this);
 	}
 
@@ -1270,14 +1270,14 @@ namespace RE
 	void Actor::AddWornOutfit(BGSOutfit* a_outfit, bool a_forceUpdate)
 	{
 		using func_t = decltype(&Actor::AddWornOutfit);
-		REL::Relocation<func_t> func{ RELOCATION_ID(19266, 19692) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19266, 19692) };
 		return func(this, a_outfit, a_forceUpdate);
 	}
 
 	void Actor::RemoveOutfitItems(BGSOutfit* a_outfit)
 	{
 		using func_t = decltype(&Actor::RemoveOutfitItems);
-		REL::Relocation<func_t> func{ RELOCATION_ID(19264, 19690) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19264, 19690) };
 		return func(this, a_outfit);
 	}
 }

--- a/src/RE/A/ActorEquipManager.cpp
+++ b/src/RE/A/ActorEquipManager.cpp
@@ -11,28 +11,28 @@ namespace RE
 	void ActorEquipManager::EquipObject(Actor* a_actor, TESBoundObject* a_object, ExtraDataList* a_extraData, std::uint32_t a_count, const BGSEquipSlot* a_slot, bool a_queueEquip, bool a_forceEquip, bool a_playSounds, bool a_applyNow)
 	{
 		using func_t = decltype(&ActorEquipManager::EquipObject);
-		REL::Relocation<func_t> func{ Offset::ActorEquipManager::EquipObject };
+		static REL::Relocation<func_t> func{ Offset::ActorEquipManager::EquipObject };
 		return func(this, a_actor, a_object, a_extraData, a_count, a_slot, a_queueEquip, a_forceEquip, a_playSounds, a_applyNow);
 	}
 
 	void ActorEquipManager::EquipShout(Actor* a_actor, TESShout* a_shout)
 	{
 		using func_t = decltype(&ActorEquipManager::EquipShout);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37941, 38897) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37941, 38897) };
 		return func(this, a_actor, a_shout);
 	}
 
 	void ActorEquipManager::EquipSpell(Actor* a_actor, SpellItem* a_spell, const BGSEquipSlot* a_slot)
 	{
 		using func_t = decltype(&ActorEquipManager::EquipSpell);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37939, 38895) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37939, 38895) };
 		return func(this, a_actor, a_spell, a_slot);
 	}
 
 	bool ActorEquipManager::UnequipObject(Actor* a_actor, TESBoundObject* a_object, ExtraDataList* a_extraData, std::uint32_t a_count, const BGSEquipSlot* a_slot, bool a_queueEquip, bool a_forceEquip, bool a_playSounds, bool a_applyNow, const BGSEquipSlot* a_slotToReplace)
 	{
 		using func_t = decltype(&ActorEquipManager::UnequipObject);
-		REL::Relocation<func_t> func{ Offset::ActorEquipManager::UnequipObject };
+		static REL::Relocation<func_t> func{ Offset::ActorEquipManager::UnequipObject };
 		return func(this, a_actor, a_object, a_extraData, a_count, a_slot, a_queueEquip, a_forceEquip, a_playSounds, a_applyNow, a_slotToReplace);
 	}
 }

--- a/src/RE/A/ActorKill.cpp
+++ b/src/RE/A/ActorKill.cpp
@@ -5,7 +5,7 @@ namespace RE
 	BSTEventSource<ActorKill::Event>* ActorKill::GetEventSource()
 	{
 		using func_t = decltype(&ActorKill::GetEventSource);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37390, 38338) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37390, 38338) };
 		return func();
 	}
 }

--- a/src/RE/A/ActorValueOwner.cpp
+++ b/src/RE/A/ActorValueOwner.cpp
@@ -5,14 +5,14 @@ namespace RE
 	float ActorValueOwner::GetArmorRatingSkillMultiplier(float a_skillLevel) const
 	{
 		using func_t = decltype(&ActorValueOwner::GetArmorRatingSkillMultiplier);
-		REL::Relocation<func_t> func(RELOCATION_ID(25858, 26424));
+		static REL::Relocation<func_t> func(RELOCATION_ID(25858, 26424));
 		return func(this, a_skillLevel);
 	}
 
 	float ActorValueOwner::GetClampedActorValue(ActorValue a_akValue) const
 	{
 		using func_t = decltype(&ActorValueOwner::GetClampedActorValue);
-		REL::Relocation<func_t> func{ Offset::ActorValueOwner::GetClampedActorValue };
+		static REL::Relocation<func_t> func{ Offset::ActorValueOwner::GetClampedActorValue };
 		return func(this, a_akValue);
 	}
 }

--- a/src/RE/A/ArmorRatingVisitor.cpp
+++ b/src/RE/A/ArmorRatingVisitor.cpp
@@ -5,14 +5,14 @@ namespace RE
 	bool ArmorRatingVisitor::HaveNotVisitedArmor(TESObjectARMO* a_armor)
 	{
 		using func_t = decltype(&ArmorRatingVisitor::HaveNotVisitedArmor);
-		REL::Relocation<func_t> func(RELOCATION_ID(39221, 40297));
+		static REL::Relocation<func_t> func(RELOCATION_ID(39221, 40297));
 		return func(this, a_armor);
 	}
 
 	void ArmorRatingVisitor::VisitArmor(TESObjectARMO* a_armor)
 	{
 		using func_t = decltype(&ArmorRatingVisitor::VisitArmor);
-		REL::Relocation<func_t> func(RELOCATION_ID(39217, 40293));
+		static REL::Relocation<func_t> func(RELOCATION_ID(39217, 40293));
 		return func(this, a_armor);
 	}
 }

--- a/src/RE/A/ArmorRatingVisitorBase.cpp
+++ b/src/RE/A/ArmorRatingVisitorBase.cpp
@@ -5,7 +5,7 @@ namespace RE
 	BSContainer::ForEachResult ArmorRatingVisitorBase::Visit(InventoryEntryData* a_entryData)
 	{
 		using func_t = decltype(&ArmorRatingVisitorBase::Visit);
-		REL::Relocation<func_t> func(RELOCATION_ID(39223, 40299));
+		static REL::Relocation<func_t> func(RELOCATION_ID(39223, 40299));
 		return func(this, a_entryData);
 	}
 }

--- a/src/RE/B/BGSCreatedObjectManager.cpp
+++ b/src/RE/B/BGSCreatedObjectManager.cpp
@@ -11,14 +11,14 @@ namespace RE
 	EnchantmentItem* BGSCreatedObjectManager::AddArmorEnchantment(BSTArray<Effect>& a_effects)
 	{
 		using func_t = decltype(&BGSCreatedObjectManager::AddArmorEnchantment);
-		REL::Relocation<func_t> func{ RELOCATION_ID(35264, 36166) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(35264, 36166) };
 		return func(this, a_effects);
 	}
 
 	EnchantmentItem* BGSCreatedObjectManager::AddWeaponEnchantment(BSTArray<Effect>& a_effects)
 	{
 		using func_t = decltype(&BGSCreatedObjectManager::AddWeaponEnchantment);
-		REL::Relocation<func_t> func{ RELOCATION_ID(35263, 36165) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(35263, 36165) };
 		return func(this, a_effects);
 	}
 }

--- a/src/RE/B/BGSListForm.cpp
+++ b/src/RE/B/BGSListForm.cpp
@@ -5,7 +5,7 @@ namespace RE
 	void BGSListForm::AddForm(TESForm* a_form)
 	{
 		using func_t = decltype(&BGSListForm::AddForm);
-		REL::Relocation<func_t> func{ Offset::BGSListForm::AddForm };
+		static REL::Relocation<func_t> func{ Offset::BGSListForm::AddForm };
 		return func(this, a_form);
 	}
 

--- a/src/RE/B/BGSOpenCloseForm.cpp
+++ b/src/RE/B/BGSOpenCloseForm.cpp
@@ -6,14 +6,14 @@ namespace RE
 		-> OPEN_STATE
 	{
 		using func_t = decltype(&BGSOpenCloseForm::GetOpenState);
-		REL::Relocation<func_t> func{ RELOCATION_ID(14180, 14288) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(14180, 14288) };
 		return func(a_ref);
 	}
 
 	void BGSOpenCloseForm::SetOpenState(TESObjectREFR* a_ref, bool a_open, bool a_snap)
 	{
 		using func_t = decltype(&BGSOpenCloseForm::SetOpenState);
-		REL::Relocation<func_t> func{ RELOCATION_ID(14179, 14287) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(14179, 14287) };
 		return func(a_ref, a_open, a_snap);
 	}
 }

--- a/src/RE/B/BGSSaveLoadManager.cpp
+++ b/src/RE/B/BGSSaveLoadManager.cpp
@@ -26,21 +26,21 @@ namespace RE
 	bool BGSSaveLoadManager::LoadMostRecentSaveGame()
 	{
 		using func_t = decltype(&BGSSaveLoadManager::LoadMostRecentSaveGame);
-		REL::Relocation<func_t> func{ RELOCATION_ID(34856, 35766) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(34856, 35766) };
 		return func(this);
 	}
 
 	bool BGSSaveLoadManager::Save_Impl(std::int32_t a_deviceID, std::uint32_t a_outputStats, const char* a_fileName)
 	{
 		using func_t = decltype(&BGSSaveLoadManager::Save_Impl);
-		REL::Relocation<func_t> func{ Offset::BGSSaveLoadManager::Save };
+		static REL::Relocation<func_t> func{ Offset::BGSSaveLoadManager::Save };
 		return func(this, a_deviceID, a_outputStats, a_fileName);
 	}
 
 	bool BGSSaveLoadManager::Load_Impl(const char* a_fileName, std::int32_t a_deviceID, std::uint32_t a_outputStats, bool a_checkForMods)
 	{
 		using func_t = decltype(&BGSSaveLoadManager::Load_Impl);
-		REL::Relocation<func_t> func{ Offset::BGSSaveLoadManager::Load };
+		static REL::Relocation<func_t> func{ Offset::BGSSaveLoadManager::Load };
 		return func(this, a_fileName, a_deviceID, a_outputStats, a_checkForMods);
 	}
 }

--- a/src/RE/B/BGSSkillPerkTreeNode.cpp
+++ b/src/RE/B/BGSSkillPerkTreeNode.cpp
@@ -5,7 +5,7 @@ namespace RE
 	BGSSkillPerkTreeNode::BGSSkillPerkTreeNode(std::int32_t a_index, ActorValueInfo* a_avInfo)
 	{
 		using func_t = BGSSkillPerkTreeNode* (*)(BGSSkillPerkTreeNode*, std::int32_t, ActorValueInfo*);
-		REL::Relocation<func_t> func{ Offset::BGSSkillPerkTreeNode::Ctor };
+		static REL::Relocation<func_t> func{ Offset::BGSSkillPerkTreeNode::Ctor };
 		func(this, a_index, a_avInfo);
 	}
 }

--- a/src/RE/B/BGSStoryTeller.cpp
+++ b/src/RE/B/BGSStoryTeller.cpp
@@ -11,14 +11,14 @@ namespace RE
 	void BGSStoryTeller::BeginShutDownQuest(TESQuest* a_quest)
 	{
 		using func_t = decltype(&BGSStoryTeller::BeginShutDownQuest);
-		REL::Relocation<func_t> func{ Offset::BGSStoryTeller::BeginShutDownQuest };
+		static REL::Relocation<func_t> func{ Offset::BGSStoryTeller::BeginShutDownQuest };
 		return func(this, a_quest);
 	}
 
 	void BGSStoryTeller::BeginStartUpQuest(TESQuest* a_quest)
 	{
 		using func_t = decltype(&BGSStoryTeller::BeginStartUpQuest);
-		REL::Relocation<func_t> func{ Offset::BGSStoryTeller::BeginStartUpQuest };
+		static REL::Relocation<func_t> func{ Offset::BGSStoryTeller::BeginStartUpQuest };
 		return func(this, a_quest);
 	}
 }

--- a/src/RE/B/BSAtomic.cpp
+++ b/src/RE/B/BSAtomic.cpp
@@ -75,28 +75,28 @@ namespace RE
 	void BSReadWriteLock::LockForRead()
 	{
 		using func_t = decltype(&BSReadWriteLock::LockForRead);
-		REL::Relocation<func_t> func{ Offset::BSReadWriteLock::LockForRead };
+		static REL::Relocation<func_t> func{ Offset::BSReadWriteLock::LockForRead };
 		func(this);
 	}
 
 	void BSReadWriteLock::UnlockForRead()
 	{
 		using func_t = decltype(&BSReadWriteLock::UnlockForRead);
-		REL::Relocation<func_t> func{ Offset::BSReadWriteLock::UnlockForRead };
+		static REL::Relocation<func_t> func{ Offset::BSReadWriteLock::UnlockForRead };
 		func(this);
 	}
 
 	void BSReadWriteLock::LockForWrite()
 	{
 		using func_t = decltype(&BSReadWriteLock::LockForWrite);
-		REL::Relocation<func_t> func{ Offset::BSReadWriteLock::LockForWrite };
+		static REL::Relocation<func_t> func{ Offset::BSReadWriteLock::LockForWrite };
 		func(this);
 	}
 
 	void BSReadWriteLock::UnlockForWrite()
 	{
 		using func_t = decltype(&BSReadWriteLock::UnlockForWrite);
-		REL::Relocation<func_t> func{ Offset::BSReadWriteLock::UnlockForWrite };
+		static REL::Relocation<func_t> func{ Offset::BSReadWriteLock::UnlockForWrite };
 		func(this);
 	}
 

--- a/src/RE/B/BSAudioManager.cpp
+++ b/src/RE/B/BSAudioManager.cpp
@@ -10,7 +10,7 @@ namespace RE
 	BSAudioManager* BSAudioManager::GetSingleton()
 	{
 		using func_t = decltype(&BSAudioManager::GetSingleton);
-		REL::Relocation<func_t> func{ Offset::BSAudioManager::GetSingleton };
+		static REL::Relocation<func_t> func{ Offset::BSAudioManager::GetSingleton };
 		return func();
 	}
 
@@ -29,21 +29,21 @@ namespace RE
 	bool BSAudioManager::BuildSoundDataFromDescriptor(BSSoundHandle& a_soundHandle, BSISoundDescriptor* a_descriptor, std::uint32_t a_flags)
 	{
 		using func_t = decltype(&BSAudioManager::BuildSoundDataFromDescriptor);
-		REL::Relocation<func_t> func{ Offset::BSAudioManager::BuildSoundDataFromDescriptor };
+		static REL::Relocation<func_t> func{ Offset::BSAudioManager::BuildSoundDataFromDescriptor };
 		return func(this, a_soundHandle, a_descriptor, a_flags);
 	}
 
 	void BSAudioManager::BuildSoundDataFromEditorID(BSSoundHandle& a_soundHandle, const char* a_editorID, std::uint32_t a_flags)
 	{
 		using func_t = decltype(&BSAudioManager::BuildSoundDataFromEditorID);
-		REL::Relocation<func_t> func{ RELOCATION_ID(66403, 67665) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(66403, 67665) };
 		return func(this, a_soundHandle, a_editorID, a_flags);
 	}
 
 	void BSAudioManager::BuildSoundDataFromFile(BSSoundHandle& a_soundHandle, const BSResource::ID& a_file, std::uint32_t a_flags, std::uint32_t a_priority)
 	{
 		using func_t = decltype(&BSAudioManager::BuildSoundDataFromFile);
-		REL::Relocation<func_t> func{ RELOCATION_ID(66402, 67664) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(66402, 67664) };
 		return func(this, a_soundHandle, a_file, a_flags, a_priority);
 	}
 }

--- a/src/RE/B/BSDirectInputManager.cpp
+++ b/src/RE/B/BSDirectInputManager.cpp
@@ -11,28 +11,28 @@ namespace RE
 	REX::W32::IDirectInputDevice8A* BSDirectInputManager::CreateDeviceWithGUID(REX::W32::GUID* a_guid)
 	{
 		using func_t = decltype(&BSDirectInputManager::CreateDeviceWithGUID);
-		REL::Relocation<func_t> func{ RELOCATION_ID(67373, 68675) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(67373, 68675) };
 		return func(this, a_guid);
 	}
 
 	void BSDirectInputManager::GetDeviceState(REX::W32::IDirectInputDevice8A* a_device, std::uint32_t a_size, void* a_outData)
 	{
 		using func_t = decltype(&BSDirectInputManager::GetDeviceState);
-		REL::Relocation<func_t> func{ RELOCATION_ID(67375, 68677) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(67375, 68677) };
 		return func(this, a_device, a_size, a_outData);
 	}
 
 	void BSDirectInputManager::GetDeviceData(REX::W32::IDirectInputDevice8A* a_device, std::uint32_t* a_dataSize, REX::W32::DIDEVICEOBJECTDATA** a_outData)
 	{
 		using func_t = decltype(&BSDirectInputManager::GetDeviceData);
-		REL::Relocation<func_t> func{ RELOCATION_ID(67376, 68678) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(67376, 68678) };
 		return func(this, a_device, a_dataSize, a_outData);
 	}
 
 	void BSDirectInputManager::ReleaseDevice(REX::W32::IDirectInputDevice8A* a_device)
 	{
 		using func_t = decltype(&BSDirectInputManager::ReleaseDevice);
-		REL::Relocation<func_t> func{ RELOCATION_ID(67374, 68676) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(67374, 68676) };
 		return func(this, a_device);
 	}
 }

--- a/src/RE/B/BSInputDevice.cpp
+++ b/src/RE/B/BSInputDevice.cpp
@@ -26,7 +26,7 @@ namespace RE
 	bool BSInputDevice::LoadControlsDefinitionFile(const char* a_fileName)
 	{
 		using func_t = decltype(&BSInputDevice::LoadControlsDefinitionFile);
-		REL::Relocation<func_t> func{ RELOCATION_ID(67438, 68745) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(67438, 68745) };
 		return func(this, a_fileName);
 	}
 
@@ -39,7 +39,7 @@ namespace RE
 	void BSInputDevice::SetButtonState(std::uint32_t a_buttonId, float a_timeSinceLastPoll, bool a_buttonWasPressed, bool a_buttonIsPressed)
 	{
 		using func_t = decltype(&BSInputDevice::SetButtonState);
-		REL::Relocation<func_t> func{ RELOCATION_ID(67441, 68748) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(67441, 68748) };
 		return func(this, a_buttonId, a_timeSinceLastPoll, a_buttonWasPressed, a_buttonIsPressed);
 	}
 }

--- a/src/RE/B/BSInputDeviceFactory.cpp
+++ b/src/RE/B/BSInputDeviceFactory.cpp
@@ -7,7 +7,7 @@ namespace RE
 	BSIInputDevice* BSInputDeviceFactory::CreateInputDevice(INPUT_DEVICE a_deviceType)
 	{
 		using func_t = decltype(&BSInputDeviceFactory::CreateInputDevice);
-		REL::Relocation<func_t> func{ RELOCATION_ID(67431, 68738) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(67431, 68738) };
 		return func(a_deviceType);
 	}
 

--- a/src/RE/B/BSInputDeviceManager.cpp
+++ b/src/RE/B/BSInputDeviceManager.cpp
@@ -124,7 +124,7 @@ namespace RE
 		// Emits the last InputEvent
 		// resets the global BSInputEventQueue
 		using func_t = decltype(&BSInputDeviceManager::PollInputDevices);
-		REL::Relocation<func_t> func{ RELOCATION_ID(67315, 68617) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(67315, 68617) };
 		return func(this, a_secsSinceLastFrame);
 	}
 }

--- a/src/RE/B/BSModelDB.cpp
+++ b/src/RE/B/BSModelDB.cpp
@@ -7,7 +7,7 @@ namespace RE
 		BSResource::ErrorCode Demand(const char* a_modelPath, NiPointer<NiNode>& a_modelOut, const DBTraits::ArgsType& a_args)
 		{
 			using func_t = decltype(&BSModelDB::Demand);
-			REL::Relocation<func_t> func{ RELOCATION_ID(74040, 75782) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(74040, 75782) };
 			return func(a_modelPath, a_modelOut, a_args);
 		}
 	}

--- a/src/RE/B/BSPCGamepadDeviceHandler.cpp
+++ b/src/RE/B/BSPCGamepadDeviceHandler.cpp
@@ -5,7 +5,7 @@ namespace RE
 	void BSPCGamepadDeviceHandler::InitializeDelegate()
 	{
 		using func_t = decltype(&BSPCGamepadDeviceHandler::InitializeDelegate);
-		REL::Relocation<func_t> func{ RELOCATION_ID(67457, 68762) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(67457, 68762) };
 		return func(this);
 	}
 

--- a/src/RE/B/BSResourceNiBinaryStream.cpp
+++ b/src/RE/B/BSResourceNiBinaryStream.cpp
@@ -37,7 +37,7 @@ namespace RE
 	void BSResourceNiBinaryStream::seek(std::int32_t a_numBytes)
 	{
 		using func_t = decltype(&BSResourceNiBinaryStream::seek);
-		REL::Relocation<func_t> func{ Offset::BSResourceNiBinaryStream::Seek };
+		static REL::Relocation<func_t> func{ Offset::BSResourceNiBinaryStream::Seek };
 		return func(this, a_numBytes);
 	}
 
@@ -52,21 +52,21 @@ namespace RE
 	void BSResourceNiBinaryStream::set_endian_swap(bool a_doSwap)
 	{
 		using func_t = decltype(&BSResourceNiBinaryStream::set_endian_swap);
-		REL::Relocation<func_t> func{ Offset::BSResourceNiBinaryStream::SetEndianSwap };
+		static REL::Relocation<func_t> func{ Offset::BSResourceNiBinaryStream::SetEndianSwap };
 		return func(this, a_doSwap);
 	}
 
 	BSResourceNiBinaryStream* BSResourceNiBinaryStream::ctor(const char* a_name, bool a_writeable, BSResource::Location* a_optionalStart)
 	{
 		using func_t = decltype(&BSResourceNiBinaryStream::ctor);
-		REL::Relocation<func_t> func{ Offset::BSResourceNiBinaryStream::Ctor };
+		static REL::Relocation<func_t> func{ Offset::BSResourceNiBinaryStream::Ctor };
 		return func(this, a_name, a_writeable, a_optionalStart);
 	}
 
 	void BSResourceNiBinaryStream::dtor()
 	{
 		using func_t = decltype(&BSResourceNiBinaryStream::dtor);
-		REL::Relocation<func_t> func{ Offset::BSResourceNiBinaryStream::Dtor };
+		static REL::Relocation<func_t> func{ Offset::BSResourceNiBinaryStream::Dtor };
 		return func(this);
 	}
 }

--- a/src/RE/B/BSScaleformManager.cpp
+++ b/src/RE/B/BSScaleformManager.cpp
@@ -18,21 +18,21 @@ namespace RE
 	bool BSScaleformManager::IsValidName(const char* a_name)
 	{
 		using func_t = decltype(&BSScaleformManager::IsValidName);
-		REL::Relocation<func_t> func{ RELOCATION_ID(80307, 82331) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(80307, 82331) };
 		return func(this, a_name);
 	}
 
 	bool BSScaleformManager::FileExists(const char* a_fileName)
 	{
 		using func_t = decltype(&BSScaleformManager::FileExists);
-		REL::Relocation<func_t> func{ RELOCATION_ID(80087, 82411) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(80087, 82411) };
 		return func(a_fileName);
 	}
 
 	bool BSScaleformManager::LoadMovie(IMenu* a_menu, GPtr<GFxMovieView>& a_viewOut, const char* a_fileName, ScaleModeType a_mode, float a_backGroundAlpha)
 	{
 		using func_t = decltype(&BSScaleformManager::LoadMovie);
-		REL::Relocation<func_t> func{ RELOCATION_ID(80302, 82325) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(80302, 82325) };
 		return func(this, a_menu, a_viewOut, a_fileName, a_mode, a_backGroundAlpha);
 	}
 

--- a/src/RE/B/BSScaleformTranslator.cpp
+++ b/src/RE/B/BSScaleformTranslator.cpp
@@ -5,7 +5,7 @@ namespace RE
 	void BSScaleformTranslator::GetCachedString(wchar_t** a_pOut, wchar_t* a_bufIn, std::uint32_t a_unused)
 	{
 		using func_t = decltype(&BSScaleformTranslator::GetCachedString);
-		REL::Relocation<func_t> func{ Offset::BSScaleformTranslator::GetCachedString };
+		static REL::Relocation<func_t> func{ Offset::BSScaleformTranslator::GetCachedString };
 		return func(a_pOut, a_bufIn, a_unused);
 	}
 }

--- a/src/RE/B/BSScriptObjectBindPolicy.cpp
+++ b/src/RE/B/BSScriptObjectBindPolicy.cpp
@@ -7,7 +7,7 @@ namespace RE
 		void ObjectBindPolicy::BindObject(BSTSmartPointer<Object>& a_objectPtr, VMHandle a_handle)
 		{
 			using func_t = decltype(&ObjectBindPolicy::BindObject);
-			REL::Relocation<func_t> func{ Offset::BSScript::ObjectBindPolicy::BindObject };
+			static REL::Relocation<func_t> func{ Offset::BSScript::ObjectBindPolicy::BindObject };
 			return func(this, a_objectPtr, a_handle);
 		}
 	}

--- a/src/RE/B/BSShaderProperty.cpp
+++ b/src/RE/B/BSShaderProperty.cpp
@@ -13,21 +13,21 @@ namespace RE
 	void BSShaderProperty::SetMaterial(BSShaderMaterial* a_material, bool a_unk1)
 	{
 		using func_t = decltype(&BSShaderProperty::SetMaterial);
-		REL::Relocation<func_t> func{ RELOCATION_ID(98897, 105544) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(98897, 105544) };
 		return func(this, a_material, a_unk1);
 	}
 
 	void BSShaderProperty::SetFlags(EShaderPropertyFlag8 a_flag, bool a_set)
 	{
 		using func_t = decltype(&BSShaderProperty::SetFlags);
-		REL::Relocation<func_t> func{ RELOCATION_ID(98893, 105540) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(98893, 105540) };
 		return func(this, a_flag, a_set);
 	}
 
 	void BSShaderProperty::LinkMaterial(BSShaderMaterial* a_material, bool a_unk1)
 	{
 		using func_t = decltype(&BSShaderProperty::LinkMaterial);
-		REL::Relocation<func_t> func{ RELOCATION_ID(98897, 105544) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(98897, 105544) };
 		return func(this, a_material, a_unk1);
 	}
 
@@ -41,14 +41,14 @@ namespace RE
 	BSRenderPass* BSShaderProperty::RenderPassArray::MakeRenderPass(BSShader* a_shader, BSShaderProperty* a_property, BSGeometry* a_geometry, uint32_t a_technique, uint8_t a_numLights, BSLight** a_lights)
 	{
 		using func_t = decltype(&BSShaderProperty::RenderPassArray::MakeRenderPass);
-		REL::Relocation<func_t> func{ RELOCATION_ID(100717, 107497) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(100717, 107497) };
 		return func(this, a_shader, a_property, a_geometry, a_technique, a_numLights, a_lights);
 	}
 
 	void BSShaderProperty::RenderPassArray::ClearRenderPass(BSRenderPass* a_pass)
 	{
 		using func_t = decltype(&RenderPassArray::ClearRenderPass);
-		REL::Relocation<func_t> func{ RELOCATION_ID(100718, 107498) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(100718, 107498) };
 		func(this, a_pass);
 	}
 

--- a/src/RE/B/BSShaderTextureSet.cpp
+++ b/src/RE/B/BSShaderTextureSet.cpp
@@ -5,7 +5,7 @@ namespace RE
 	BSShaderTextureSet* BSShaderTextureSet::Ctor()
 	{
 		using func_t = decltype(&BSShaderTextureSet::Ctor);
-		REL::Relocation<func_t> func{ REL::ID(99886) };
+		static REL::Relocation<func_t> func{ REL::ID(99886) };
 		return func(this);
 	}
 
@@ -13,7 +13,7 @@ namespace RE
 	{
 #ifdef SKYRIM_SUPPORT_AE
 		using func_t = decltype(&BSShaderTextureSet::Create);
-		REL::Relocation<func_t> func{ REL::ID(107172) };
+		static REL::Relocation<func_t> func{ REL::ID(107172) };
 		return func();
 #else
 		auto textureset = malloc<BSShaderTextureSet>();

--- a/src/RE/B/BSSoundHandle.cpp
+++ b/src/RE/B/BSSoundHandle.cpp
@@ -15,91 +15,91 @@ namespace RE
 	bool BSSoundHandle::FadeInPlay(std::uint16_t a_fadeTimeMS)
 	{
 		using func_t = decltype(&BSSoundHandle::FadeInPlay);
-		REL::Relocation<func_t> func{ RELOCATION_ID(66384, 67645) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(66384, 67645) };
 		return func(this, a_fadeTimeMS);
 	}
 
 	bool BSSoundHandle::FadeOutAndRelease(std::uint16_t a_fadeTimeMS)
 	{
 		using func_t = decltype(&BSSoundHandle::FadeOutAndRelease);
-		REL::Relocation<func_t> func{ RELOCATION_ID(66385, 67646) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(66385, 67646) };
 		return func(this, a_fadeTimeMS);
 	}
 
 	std::uint64_t BSSoundHandle::GetDuration()
 	{
 		using func_t = decltype(&BSSoundHandle::GetDuration);
-		REL::Relocation<func_t> func{ RELOCATION_ID(66369, 67630) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(66369, 67630) };
 		return func(this);
 	}
 
 	bool BSSoundHandle::IsPlaying() const
 	{
 		using func_t = decltype(&BSSoundHandle::IsPlaying);
-		REL::Relocation<func_t> func{ RELOCATION_ID(66359, 67620) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(66359, 67620) };
 		return func(this);
 	}
 
 	bool BSSoundHandle::IsValid() const
 	{
 		using func_t = decltype(&BSSoundHandle::IsValid);
-		REL::Relocation<func_t> func{ Offset::BSSoundHandle::IsValid };
+		static REL::Relocation<func_t> func{ Offset::BSSoundHandle::IsValid };
 		return func(this);
 	}
 
 	bool BSSoundHandle::SetFrequency(float a_frequency)
 	{
 		using func_t = decltype(&BSSoundHandle::SetFrequency);
-		REL::Relocation<func_t> func{ RELOCATION_ID(66366, 67627) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(66366, 67627) };
 		return func(this, a_frequency);
 	}
 
 	bool BSSoundHandle::SetPosition(NiPoint3 a_pos)
 	{
 		using func_t = decltype(&BSSoundHandle::SetPosition);
-		REL::Relocation<func_t> func{ Offset::BSSoundHandle::SetPosition };
+		static REL::Relocation<func_t> func{ Offset::BSSoundHandle::SetPosition };
 		return func(this, a_pos);
 	}
 
 	void BSSoundHandle::SetObjectToFollow(NiAVObject* a_node)
 	{
 		using func_t = decltype(&BSSoundHandle::SetObjectToFollow);
-		REL::Relocation<func_t> func{ Offset::BSSoundHandle::SetObjectToFollow };
+		static REL::Relocation<func_t> func{ Offset::BSSoundHandle::SetObjectToFollow };
 		return func(this, a_node);
 	}
 
 	void BSSoundHandle::SetOutputModel(const BSISoundOutputModel* a_outputModel)
 	{
 		using func_t = decltype(&BSSoundHandle::SetOutputModel);
-		REL::Relocation<func_t> func{ RELOCATION_ID(66363, 67624) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(66363, 67624) };
 		return func(this, a_outputModel);
 	}
 
 	bool BSSoundHandle::SetVolume(float a_volume)
 	{
 		using func_t = decltype(&BSSoundHandle::SetVolume);
-		REL::Relocation<func_t> func{ RELOCATION_ID(66365, 67626) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(66365, 67626) };
 		return func(this, a_volume);
 	}
 
 	bool BSSoundHandle::Stop()
 	{
 		using func_t = decltype(&BSSoundHandle::Stop);
-		REL::Relocation<func_t> func{ Offset::BSSoundHandle::Stop };
+		static REL::Relocation<func_t> func{ Offset::BSSoundHandle::Stop };
 		return func(this);
 	}
 
 	bool BSSoundHandle::Play()
 	{
 		using func_t = decltype(&BSSoundHandle::Play);
-		REL::Relocation<func_t> func{ Offset::BSSoundHandle::Play };
+		static REL::Relocation<func_t> func{ Offset::BSSoundHandle::Play };
 		return func(this);
 	}
 
 	bool BSSoundHandle::Pause()
 	{
 		using func_t = decltype(&BSSoundHandle::Pause);
-		REL::Relocation<func_t> func{ Offset::BSSoundHandle::Pause };
+		static REL::Relocation<func_t> func{ Offset::BSSoundHandle::Pause };
 		return func(this);
 	}
 }

--- a/src/RE/B/BSStringPool.cpp
+++ b/src/RE/B/BSStringPool.cpp
@@ -5,7 +5,7 @@ namespace RE
 	BucketTable* BucketTable::GetSingleton()
 	{
 		using func_t = decltype(&BucketTable::GetSingleton);
-		REL::Relocation<func_t> func{ Offset::BucketTable::GetSingleton };
+		static REL::Relocation<func_t> func{ Offset::BucketTable::GetSingleton };
 		return func();
 	}
 }

--- a/src/RE/B/BSTCreateFactoryManager.cpp
+++ b/src/RE/B/BSTCreateFactoryManager.cpp
@@ -5,7 +5,7 @@ namespace RE
 	MessageDataFactoryManager* MessageDataFactoryManager::GetSingleton()
 	{
 		using func_t = decltype(&MessageDataFactoryManager::GetSingleton);
-		REL::Relocation<func_t> func{ Offset::MessageDataFactoryManager::GetSingleton };
+		static REL::Relocation<func_t> func{ Offset::MessageDataFactoryManager::GetSingleton };
 		return func();
 	}
 }

--- a/src/RE/B/BSWin32SaveDataSystemUtility.cpp
+++ b/src/RE/B/BSWin32SaveDataSystemUtility.cpp
@@ -5,7 +5,7 @@ namespace RE
 	BSWin32SaveDataSystemUtility* BSWin32SaveDataSystemUtility::GetSingleton()
 	{
 		using func_t = decltype(&BSWin32SaveDataSystemUtility::GetSingleton);
-		REL::Relocation<func_t> func{ Offset::BSWin32SaveDataSystemUtility::GetSingleton };
+		static REL::Relocation<func_t> func{ Offset::BSWin32SaveDataSystemUtility::GetSingleton };
 		return func();
 	}
 }

--- a/src/RE/B/BSWindModifier.cpp
+++ b/src/RE/B/BSWindModifier.cpp
@@ -7,7 +7,7 @@ namespace RE
 	BSWindModifier* BSWindModifier::Ctor()
 	{
 		using func_t = decltype(&BSWindModifier::Ctor);
-		REL::Relocation<func_t> func{ RELOCATION_ID(74377, 76100) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(74377, 76100) };
 		return func(this);
 	}
 

--- a/src/RE/B/BipedAnim.cpp
+++ b/src/RE/B/BipedAnim.cpp
@@ -13,14 +13,14 @@ namespace RE
 	void BipedAnim::RemoveAllParts()
 	{
 		using func_t = decltype(&BipedAnim::RemoveAllParts);
-		REL::Relocation<func_t> func{ Offset::BipedAnim::RemoveAllParts };
+		static REL::Relocation<func_t> func{ Offset::BipedAnim::RemoveAllParts };
 		return func(this);
 	}
 
 	void BipedAnim::Dtor()
 	{
 		using func_t = decltype(&BipedAnim::Dtor);
-		REL::Relocation<func_t> func{ Offset::BipedAnim::Dtor };
+		static REL::Relocation<func_t> func{ Offset::BipedAnim::Dtor };
 		return func(this);
 	}
 }

--- a/src/RE/B/BookMenu.cpp
+++ b/src/RE/B/BookMenu.cpp
@@ -20,7 +20,7 @@ namespace RE
 	void BookMenu::OpenBookMenu(const BSString& a_description, const ExtraDataList* a_extraList, TESObjectREFR* a_ref, TESObjectBOOK* a_book, const NiPoint3& a_pos, const NiMatrix3& a_rot, float a_scale, bool a_useDefaultPos)
 	{
 		using func_t = decltype(&BookMenu::OpenBookMenu);
-		REL::Relocation<func_t> func{ RELOCATION_ID(50122, 51053) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(50122, 51053) };
 		return func(a_description, a_extraList, a_ref, a_book, a_pos, a_rot, a_scale, a_useDefaultPos);
 	}
 }

--- a/src/RE/B/BooksRead.cpp
+++ b/src/RE/B/BooksRead.cpp
@@ -5,7 +5,7 @@ namespace RE
 	BSTEventSource<BooksRead::Event>* BooksRead::GetEventSource()
 	{
 		using func_t = decltype(&BooksRead::GetEventSource);
-		REL::Relocation<func_t> func{ RELOCATION_ID(17470, 17865) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(17470, 17865) };
 		return func();
 	}
 }

--- a/src/RE/B/bhkRigidBody.cpp
+++ b/src/RE/B/bhkRigidBody.cpp
@@ -12,28 +12,28 @@ namespace RE
 	void bhkRigidBody::SetAngularImpulse(const hkVector4& a_impulse)
 	{
 		using func_t = decltype(&bhkRigidBody::SetAngularImpulse);
-		REL::Relocation<func_t> func{ RELOCATION_ID(76262, 78092) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(76262, 78092) };
 		return func(this, a_impulse);
 	}
 
 	void bhkRigidBody::SetAngularVelocity(const hkVector4& a_newVel)
 	{
 		using func_t = decltype(&bhkRigidBody::SetAngularVelocity);
-		REL::Relocation<func_t> func{ RELOCATION_ID(76260, 78090) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(76260, 78090) };
 		return func(this, a_newVel);
 	}
 
 	void bhkRigidBody::SetLinearImpulse(const hkVector4& a_impulse)
 	{
 		using func_t = decltype(&bhkRigidBody::SetLinearImpulse);
-		REL::Relocation<func_t> func{ RELOCATION_ID(76261, 78091) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(76261, 78091) };
 		return func(this, a_impulse);
 	}
 
 	void bhkRigidBody::SetLinearVelocity(const hkVector4& a_newVel)
 	{
 		using func_t = decltype(&bhkRigidBody::SetLinearVelocity);
-		REL::Relocation<func_t> func{ RELOCATION_ID(76259, 78089) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(76259, 78089) };
 		return func(this, a_newVel);
 	}
 }

--- a/src/RE/C/Calendar.cpp
+++ b/src/RE/C/Calendar.cpp
@@ -72,7 +72,7 @@ namespace RE
 	void Calendar::GetTimeDateString(char* a_dest, std::uint32_t a_max, bool a_showYear) const
 	{
 		using func_t = decltype(&Calendar::GetTimeDateString);
-		REL::Relocation<func_t> func{ RELOCATION_ID(35413, 36311) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(35413, 36311) };
 		return func(this, a_dest, a_max, a_showYear);
 	}
 

--- a/src/RE/C/ChestsLooted.cpp
+++ b/src/RE/C/ChestsLooted.cpp
@@ -5,7 +5,7 @@ namespace RE
 	BSTEventSource<ChestsLooted::Event>* ChestsLooted::GetEventSource()
 	{
 		using func_t = decltype(&ChestsLooted::GetEventSource);
-		REL::Relocation<func_t> func{ RELOCATION_ID(50257, 51182) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(50257, 51182) };
 		return func();
 	}
 

--- a/src/RE/C/Console.cpp
+++ b/src/RE/C/Console.cpp
@@ -36,7 +36,7 @@ namespace RE
 	void Console::SetSelectedRef_Impl(ObjectRefHandle& a_handle)
 	{
 		using func_t = decltype(&Console::SetSelectedRef_Impl);
-		REL::Relocation<func_t> func{ Offset::Console::SetSelectedRef };
+		static REL::Relocation<func_t> func{ Offset::Console::SetSelectedRef };
 		return func(this, a_handle);
 	}
 }

--- a/src/RE/C/ConsoleLog.cpp
+++ b/src/RE/C/ConsoleLog.cpp
@@ -25,7 +25,7 @@ namespace RE
 	void ConsoleLog::VPrint(const char* a_fmt, std::va_list a_args)
 	{
 		using func_t = decltype(&ConsoleLog::Print);
-		REL::Relocation<func_t> func{ Offset::ConsoleLog::VPrint };
+		static REL::Relocation<func_t> func{ Offset::ConsoleLog::VPrint };
 		func(this, a_fmt, a_args);
 	}
 }

--- a/src/RE/C/ControlMap.cpp
+++ b/src/RE/C/ControlMap.cpp
@@ -71,14 +71,14 @@ namespace RE
 	void ControlMap::PopInputContext(InputContextID a_context)
 	{
 		using func_t = decltype(&ControlMap::PopInputContext);
-		REL::Relocation<func_t> func{ RELOCATION_ID(67244, 68544) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(67244, 68544) };
 		return func(this, a_context);
 	}
 
 	void ControlMap::PushInputContext(InputContextID a_context)
 	{
 		using func_t = decltype(&ControlMap::PushInputContext);
-		REL::Relocation<func_t> func{ RELOCATION_ID(67243, 68543) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(67243, 68543) };
 		return func(this, a_context);
 	}
 

--- a/src/RE/C/CriticalHit.cpp
+++ b/src/RE/C/CriticalHit.cpp
@@ -5,7 +5,7 @@ namespace RE
 	BSTEventSource<CriticalHit::Event>* CriticalHit::GetEventSource()
 	{
 		using func_t = decltype(&CriticalHit::GetEventSource);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37726, 38671) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37726, 38671) };
 		return func();
 	}
 }

--- a/src/RE/D/DisarmedEvent.cpp
+++ b/src/RE/D/DisarmedEvent.cpp
@@ -5,7 +5,7 @@ namespace RE
 	BSTEventSource<DisarmedEvent::Event>* DisarmedEvent::GetEventSource()
 	{
 		using func_t = decltype(&DisarmedEvent::GetEventSource);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37392, 38340) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37392, 38340) };
 		return func();
 	}
 }

--- a/src/RE/D/DragonSoulsGained.cpp
+++ b/src/RE/D/DragonSoulsGained.cpp
@@ -5,7 +5,7 @@ namespace RE
 	BSTEventSource<DragonSoulsGained::Event>* DragonSoulsGained::GetEventSource()
 	{
 		using func_t = decltype(&DragonSoulsGained::GetEventSource);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37571, 38520) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37571, 38520) };
 		return func();
 	}
 }

--- a/src/RE/E/EnchantConstructMenu.cpp
+++ b/src/RE/E/EnchantConstructMenu.cpp
@@ -15,14 +15,14 @@ namespace RE
 		void EnchantConstructMenu::RenameItem_Impl(InventoryEntryData* a_entryData, ExtraDataList* a_extraList, const char* a_name)
 		{
 			using func_t = decltype(&EnchantConstructMenu::RenameItem_Impl);
-			REL::Relocation<func_t> func{ Offset::CraftingSubMenus::EnchantConstructMenu::RenameItem };
+			static REL::Relocation<func_t> func{ Offset::CraftingSubMenus::EnchantConstructMenu::RenameItem };
 			return func(this, a_entryData, a_extraList, a_name);
 		}
 
 		void EnchantConstructMenu::UpdateInterface()
 		{
 			using func_t = decltype(&EnchantConstructMenu::UpdateInterface);
-			REL::Relocation<func_t> func{ Offset::CraftingSubMenus::EnchantConstructMenu::UpdateInterface };
+			static REL::Relocation<func_t> func{ Offset::CraftingSubMenus::EnchantConstructMenu::UpdateInterface };
 			return func(this);
 		}
 	}

--- a/src/RE/E/ExtraDataList.cpp
+++ b/src/RE/E/ExtraDataList.cpp
@@ -168,7 +168,7 @@ namespace RE
 	BSExtraData* ExtraDataList::Add(BSExtraData* a_toAdd)
 	{
 		using func_t = decltype(&ExtraDataList::Add);
-		REL::Relocation<func_t> func{ Offset::ExtraDataList::Add };
+		static REL::Relocation<func_t> func{ Offset::ExtraDataList::Add };
 		return func(this, a_toAdd);
 	}
 
@@ -285,14 +285,14 @@ namespace RE
 	bool ExtraDataList::HasQuestObjectAlias()
 	{
 		using func_t = decltype(&ExtraDataList::HasQuestObjectAlias);
-		REL::Relocation<func_t> func{ RELOCATION_ID(11913, 12052) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(11913, 12052) };
 		return func(this);
 	}
 
 	void ExtraDataList::SetCount(std::uint16_t a_count)
 	{
 		using func_t = decltype(&ExtraDataList::SetCount);
-		REL::Relocation<func_t> func{ Offset::ExtraDataList::SetCount };
+		static REL::Relocation<func_t> func{ Offset::ExtraDataList::SetCount };
 		return func(this, a_count);
 	}
 
@@ -313,21 +313,21 @@ namespace RE
 	void ExtraDataList::SetExtraFlags(ExtraFlags::Flag a_flags, bool a_enable)
 	{
 		using func_t = decltype(&ExtraDataList::SetExtraFlags);
-		REL::Relocation<func_t> func{ Offset::ExtraDataList::SetExtraFlags };
+		static REL::Relocation<func_t> func{ Offset::ExtraDataList::SetExtraFlags };
 		return func(this, a_flags, a_enable);
 	}
 
 	void ExtraDataList::SetHeadingTargetRefHandle(ObjectRefHandle& a_handle)
 	{
 		using func_t = decltype(&ExtraDataList::SetHeadingTargetRefHandle);
-		REL::Relocation<func_t> func{ RELOCATION_ID(11530, 11676) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(11530, 11676) };
 		return func(this, a_handle);
 	}
 
 	void ExtraDataList::SetInventoryChanges(InventoryChanges* a_changes)
 	{
 		using func_t = decltype(&ExtraDataList::SetInventoryChanges);
-		REL::Relocation<func_t> func{ Offset::ExtraDataList::SetInventoryChanges };
+		static REL::Relocation<func_t> func{ Offset::ExtraDataList::SetInventoryChanges };
 		return func(this, a_changes);
 	}
 
@@ -348,7 +348,7 @@ namespace RE
 	void ExtraDataList::SetLinkedRef(TESObjectREFR* a_targetRef, BGSKeyword* a_keyword)
 	{
 		using func_t = decltype(&ExtraDataList::SetLinkedRef);
-		REL::Relocation<func_t> func{ RELOCATION_ID(11633, 11779) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(11633, 11779) };
 		return func(this, a_targetRef, a_keyword);
 	}
 

--- a/src/RE/E/ExtraLock.cpp
+++ b/src/RE/E/ExtraLock.cpp
@@ -6,7 +6,7 @@ namespace RE
 	{
 		if (IsLocked()) {
 			using func_t = decltype(&REFR_LOCK::GetLockLevel);
-			REL::Relocation<func_t> func{ RELOCATION_ID(12272, 12399) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(12272, 12399) };
 			return func(this, a_containerRef);
 		} else {
 			return LOCK_LEVEL::kUnlocked;

--- a/src/RE/E/ExtraTextDisplayData.cpp
+++ b/src/RE/E/ExtraTextDisplayData.cpp
@@ -54,7 +54,7 @@ namespace RE
 	const char* ExtraTextDisplayData::GetDisplayName(TESBoundObject* a_baseObject, float a_temperFactor)
 	{
 		using func_t = decltype(&ExtraTextDisplayData::GetDisplayName);
-		REL::Relocation<func_t> func{ RELOCATION_ID(12626, 12768) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(12626, 12768) };
 		return func(this, a_baseObject, a_temperFactor);
 	}
 

--- a/src/RE/F/FindMaxMagnitudeVisitor.cpp
+++ b/src/RE/F/FindMaxMagnitudeVisitor.cpp
@@ -7,7 +7,7 @@ namespace RE
 	BSContainer::ForEachResult FindMaxMagnitudeVisitor::Accept(ActiveEffect* a_effect)
 	{
 		using func_t = decltype(&FindMaxMagnitudeVisitor::Accept);
-		REL::Relocation<func_t> func{ reinterpret_cast<std::uintptr_t*>(RELOCATION_ID(257550, 205805).address())[0x1] };  // AE address/ID untested
+		static REL::Relocation<func_t> func{ reinterpret_cast<std::uintptr_t*>(RELOCATION_ID(257550, 205805).address())[0x1] };  // AE address/ID untested
 		return func(this, a_effect);
 	}
 }  // namespace RE

--- a/src/RE/G/GFxLoader.cpp
+++ b/src/RE/G/GFxLoader.cpp
@@ -5,7 +5,7 @@ namespace RE
 	GFxMovieDef* GFxLoader::CreateMovie(const char* a_filename, LoadConstants a_loadConstants, UPInt a_memoryArena)
 	{
 		using func_t = decltype(&GFxLoader::CreateMovie);
-		REL::Relocation<func_t> func{ Offset::GFxLoader::CreateMovie };
+		static REL::Relocation<func_t> func{ Offset::GFxLoader::CreateMovie };
 		return func(this, a_filename, a_loadConstants, a_memoryArena);
 	}
 

--- a/src/RE/G/GFxMovieView.cpp
+++ b/src/RE/G/GFxMovieView.cpp
@@ -10,7 +10,7 @@ namespace RE
 	void GFxMovieView::InvokeNoReturn(const char* a_methodName, const GFxValue* a_args, std::uint32_t a_numArgs)
 	{
 		using func_t = decltype(&GFxMovieView::InvokeNoReturn);
-		REL::Relocation<func_t> func{ Offset::GFxMovieView::InvokeNoReturn };
+		static REL::Relocation<func_t> func{ Offset::GFxMovieView::InvokeNoReturn };
 		return func(this, a_methodName, a_args, a_numArgs);
 	}
 }

--- a/src/RE/G/GFxValue.cpp
+++ b/src/RE/G/GFxValue.cpp
@@ -273,168 +273,168 @@ namespace RE
 	void GFxValue::ObjectInterface::ObjectAddRef(GFxValue* a_val, void* a_obj)
 	{
 		using func_t = decltype(&GFxValue::ObjectInterface::ObjectAddRef);
-		REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::ObjectAddRef };
+		static REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::ObjectAddRef };
 		return func(this, a_val, a_obj);
 	}
 
 	void GFxValue::ObjectInterface::ObjectRelease(GFxValue* a_val, void* a_obj)
 	{
 		using func_t = decltype(&GFxValue::ObjectInterface::ObjectRelease);
-		REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::ObjectRelease };
+		static REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::ObjectRelease };
 		return func(this, a_val, a_obj);
 	}
 
 	bool GFxValue::ObjectInterface::HasMember(void* a_data, const char* a_name, bool a_isDObj) const
 	{
 		using func_t = decltype(&GFxValue::ObjectInterface::HasMember);
-		REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::HasMember };
+		static REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::HasMember };
 		return func(this, a_data, a_name, a_isDObj);
 	}
 
 	bool GFxValue::ObjectInterface::GetMember(void* a_data, const char* a_name, GFxValue* a_val, bool a_isDObj) const
 	{
 		using func_t = decltype(&GFxValue::ObjectInterface::GetMember);
-		REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::GetMember };
+		static REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::GetMember };
 		return func(this, a_data, a_name, a_val, a_isDObj);
 	}
 
 	bool GFxValue::ObjectInterface::SetMember(void* a_data, const char* a_name, const GFxValue& a_value, bool a_isDObj)
 	{
 		using func_t = decltype(&GFxValue::ObjectInterface::SetMember);
-		REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::SetMember };
+		static REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::SetMember };
 		return func(this, a_data, a_name, a_value, a_isDObj);
 	}
 
 	bool GFxValue::ObjectInterface::Invoke(void* a_data, GFxValue* a_result, const char* a_name, const GFxValue* a_args, UPInt a_numArgs, bool isDObj)
 	{
 		using func_t = decltype(&GFxValue::ObjectInterface::Invoke);
-		REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::Invoke };
+		static REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::Invoke };
 		return func(this, a_data, a_result, a_name, a_args, a_numArgs, isDObj);
 	}
 
 	bool GFxValue::ObjectInterface::DeleteMember(void* a_data, const char* a_name, bool a_isDObj)
 	{
 		using func_t = decltype(&GFxValue::ObjectInterface::DeleteMember);
-		REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::DeleteMember };
+		static REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::DeleteMember };
 		return func(this, a_data, a_name, a_isDObj);
 	}
 
 	void GFxValue::ObjectInterface::VisitMembers(void* a_data, ObjVisitor* a_visitor, bool a_isDObj) const
 	{
 		using func_t = decltype(&GFxValue::ObjectInterface::VisitMembers);
-		REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::VisitMembers };
+		static REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::VisitMembers };
 		return func(this, a_data, a_visitor, a_isDObj);
 	}
 
 	std::uint32_t GFxValue::ObjectInterface::GetArraySize(void* a_data) const
 	{
 		using func_t = decltype(&GFxValue::ObjectInterface::GetArraySize);
-		REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::GetArraySize };
+		static REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::GetArraySize };
 		return func(this, a_data);
 	}
 
 	bool GFxValue::ObjectInterface::SetArraySize(void* a_data, std::uint32_t a_size)
 	{
 		using func_t = decltype(&GFxValue::ObjectInterface::SetArraySize);
-		REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::SetArraySize };
+		static REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::SetArraySize };
 		return func(this, a_data, a_size);
 	}
 
 	bool GFxValue::ObjectInterface::GetElement(void* a_data, std::uint32_t a_idx, GFxValue* a_val) const
 	{
 		using func_t = decltype(&GFxValue::ObjectInterface::GetElement);
-		REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::GetElement };
+		static REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::GetElement };
 		return func(this, a_data, a_idx, a_val);
 	}
 
 	bool GFxValue::ObjectInterface::SetElement(void* a_data, std::uint32_t a_idx, const GFxValue& a_val)
 	{
 		using func_t = decltype(&GFxValue::ObjectInterface::SetElement);
-		REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::SetElement };
+		static REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::SetElement };
 		return func(this, a_data, a_idx, a_val);
 	}
 
 	bool GFxValue::ObjectInterface::PushBack(void* a_data, const GFxValue& a_value)
 	{
 		using func_t = decltype(&GFxValue::ObjectInterface::PushBack);
-		REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::PushBack };
+		static REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::PushBack };
 		return func(this, a_data, a_value);
 	}
 
 	bool GFxValue::ObjectInterface::RemoveElements(void* a_data, std::uint32_t a_idx, std::int32_t a_count)
 	{
 		using func_t = decltype(&GFxValue::ObjectInterface::RemoveElements);
-		REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::RemoveElements };
+		static REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::RemoveElements };
 		return func(this, a_data, a_idx, a_count);
 	}
 
 	bool GFxValue::ObjectInterface::GetDisplayInfo(void* a_data, DisplayInfo* a_info) const
 	{
 		using func_t = decltype(&GFxValue::ObjectInterface::GetDisplayInfo);
-		REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::GetDisplayInfo };
+		static REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::GetDisplayInfo };
 		return func(this, a_data, a_info);
 	}
 
 	bool GFxValue::ObjectInterface::SetDisplayInfo(void* a_data, const DisplayInfo& a_info)
 	{
 		using func_t = decltype(&GFxValue::ObjectInterface::SetDisplayInfo);
-		REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::SetDisplayInfo };
+		static REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::SetDisplayInfo };
 		return func(this, a_data, a_info);
 	}
 
 	bool GFxValue::ObjectInterface::GetDisplayMatrix(void* a_data, GMatrix2D* a_mat) const
 	{
 		using func_t = decltype(&GFxValue::ObjectInterface::GetDisplayMatrix);
-		REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::GetDisplayMatrix };
+		static REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::GetDisplayMatrix };
 		return func(this, a_data, a_mat);
 	}
 
 	bool GFxValue::ObjectInterface::SetDisplayMatrix(void* a_data, const GMatrix2D& a_mat)
 	{
 		using func_t = decltype(&GFxValue::ObjectInterface::SetDisplayMatrix);
-		REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::SetDisplayMatrix };
+		static REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::SetDisplayMatrix };
 		return func(this, a_data, a_mat);
 	}
 
 	bool GFxValue::ObjectInterface::GetCxform(void* a_data, GRenderer::Cxform* a_cx) const
 	{
 		using func_t = decltype(&GFxValue::ObjectInterface::GetCxform);
-		REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::GetCxform };
+		static REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::GetCxform };
 		return func(this, a_data, a_cx);
 	}
 
 	bool GFxValue::ObjectInterface::SetCxform(void* a_data, const GRenderer::Cxform& a_cx)
 	{
 		using func_t = decltype(&GFxValue::ObjectInterface::SetCxform);
-		REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::SetCxform };
+		static REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::SetCxform };
 		return func(this, a_data, a_cx);
 	}
 
 	bool GFxValue::ObjectInterface::SetText(void* a_data, const char* a_text, bool a_isHTML)
 	{
 		using func_t = decltype(&GFxValue::ObjectInterface::SetText);
-		REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::SetText };
+		static REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::SetText };
 		return func(this, a_data, a_text, a_isHTML);
 	}
 
 	bool GFxValue::ObjectInterface::AttachMovie(void* a_data, GFxValue* a_movieClip, const char* a_symbolName, const char* a_instanceName, std::int32_t a_depth, const GFxValue* a_initObj)
 	{
 		using func_t = decltype(&GFxValue::ObjectInterface::AttachMovie);
-		REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::AttachMovie };
+		static REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::AttachMovie };
 		return func(this, a_data, a_movieClip, a_symbolName, a_instanceName, a_depth, a_initObj);
 	}
 
 	bool GFxValue::ObjectInterface::CreateEmptyMovieClip(void* a_data, GFxValue* a_movieClip, const char* a_instanceName, std::int32_t a_depth)
 	{
 		using func_t = decltype(&GFxValue::ObjectInterface::CreateEmptyMovieClip);
-		REL::Relocation<func_t> func{ RELOCATION_ID(80201, 82224) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(80201, 82224) };
 		return func(this, a_data, a_movieClip, a_instanceName, a_depth);
 	}
 
 	bool GFxValue::ObjectInterface::GotoAndPlay(void* a_data, const char* a_frame, bool a_stop)
 	{
 		using func_t = decltype(&GFxValue::ObjectInterface::GotoAndPlay);
-		REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::GotoAndPlay };
+		static REL::Relocation<func_t> func{ Offset::GFxValue::ObjectInterface::GotoAndPlay };
 		return func(this, a_data, a_frame, a_stop);
 	}
 

--- a/src/RE/G/GString.cpp
+++ b/src/RE/G/GString.cpp
@@ -260,7 +260,7 @@ namespace RE
 	GString* GString::ctor(const char* a_str)
 	{
 		using func_t = decltype(&GString::ctor);
-		REL::Relocation<func_t> func{ RELOCATION_ID(80446, 82562) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(80446, 82562) };
 		return func(this, a_str);
 	}
 

--- a/src/RE/H/hkReferencedObject.cpp
+++ b/src/RE/H/hkReferencedObject.cpp
@@ -21,7 +21,7 @@ namespace RE
 	void hkReferencedObject::AddReference() const
 	{
 		using func_t = decltype(&hkReferencedObject::AddReference);
-		REL::Relocation<func_t> func{ Offset::hkReferencedObject::AddReference };
+		static REL::Relocation<func_t> func{ Offset::hkReferencedObject::AddReference };
 		return func(this);
 	}
 
@@ -38,7 +38,7 @@ namespace RE
 	void hkReferencedObject::RemoveReference() const
 	{
 		using func_t = decltype(&hkReferencedObject::RemoveReference);
-		REL::Relocation<func_t> func{ Offset::hkReferencedObject::RemoveReference };
+		static REL::Relocation<func_t> func{ Offset::hkReferencedObject::RemoveReference };
 		return func(this);
 	}
 }

--- a/src/RE/H/hkStringPtr.cpp
+++ b/src/RE/H/hkStringPtr.cpp
@@ -6,7 +6,7 @@ namespace RE
 		_data(nullptr)
 	{
 		using func_t = std::add_pointer_t<void(hkStringPtr&, const char*)>;
-		REL::Relocation<func_t> func{ RELOCATION_ID(56801, 57231) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(56801, 57231) };
 		func(*this, a_data);
 	}
 

--- a/src/RE/H/hkpWorldObject.cpp
+++ b/src/RE/H/hkpWorldObject.cpp
@@ -50,14 +50,14 @@ namespace RE
 	void hkpWorldObject::RemoveProperty(std::uint32_t a_key)
 	{
 		using func_t = decltype(&hkpWorldObject::RemoveProperty);
-		REL::Relocation<func_t> func{ RELOCATION_ID(75976, 77802) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(75976, 77802) };
 		return func(this, a_key);
 	}
 
 	void hkpWorldObject::SetProperty(std::uint32_t a_key, hkpPropertyValue a_value)
 	{
 		using func_t = decltype(&hkpWorldObject::SetProperty);
-		REL::Relocation<func_t> func{ RELOCATION_ID(60628, 61479) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(60628, 61479) };
 		return func(this, a_key, a_value);
 	}
 }

--- a/src/RE/I/IAnimationGraphManagerHolder.cpp
+++ b/src/RE/I/IAnimationGraphManagerHolder.cpp
@@ -25,7 +25,7 @@ namespace RE
 	bool IAnimationGraphManagerHolder::GetGraphVariableNiPoint3(const BSFixedString& a_variableName, NiPoint3& a_out) const
 	{
 		using func_t = decltype(&IAnimationGraphManagerHolder::GetGraphVariableNiPoint3);
-		REL::Relocation<func_t> func{ RELOCATION_ID(32192, 32884) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(32192, 32884) };
 		return func(this, a_variableName, a_out);
 	}
 
@@ -37,35 +37,35 @@ namespace RE
 	bool IAnimationGraphManagerHolder::SetGraphVariableBool(const BSFixedString& a_variableName, bool a_in)
 	{
 		using func_t = decltype(&IAnimationGraphManagerHolder::SetGraphVariableBool);
-		REL::Relocation<func_t> func{ RELOCATION_ID(32141, 32885) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(32141, 32885) };
 		return func(this, a_variableName, a_in);
 	}
 
 	bool IAnimationGraphManagerHolder::SetGraphVariableInt(const BSFixedString& a_variableName, std::int32_t a_in)
 	{
 		using func_t = decltype(&IAnimationGraphManagerHolder::SetGraphVariableInt);
-		REL::Relocation<func_t> func{ RELOCATION_ID(32142, 32886) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(32142, 32886) };
 		return func(this, a_variableName, a_in);
 	}
 
 	bool IAnimationGraphManagerHolder::SetGraphVariableFloat(const BSFixedString& a_variableName, float a_in)
 	{
 		using func_t = decltype(&IAnimationGraphManagerHolder::SetGraphVariableFloat);
-		REL::Relocation<func_t> func{ RELOCATION_ID(32143, 32887) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(32143, 32887) };
 		return func(this, a_variableName, a_in);
 	}
 
 	bool IAnimationGraphManagerHolder::SetGraphVariableNiPoint3(const BSFixedString& a_variableName, NiPoint3& a_in) const
 	{
 		using func_t = decltype(&IAnimationGraphManagerHolder::SetGraphVariableNiPoint3);
-		REL::Relocation<func_t> func{ RELOCATION_ID(32144, 32888) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(32144, 32888) };
 		return func(this, a_variableName, a_in);
 	}
 
 	bool IAnimationGraphManagerHolder::UpdateAnimationGraphManager(const BSAnimationUpdateData& a_updateData)
 	{
 		using func_t = decltype(&IAnimationGraphManagerHolder::UpdateAnimationGraphManager);
-		REL::Relocation<func_t> func{ RELOCATION_ID(32155, 32899) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(32155, 32899) };
 		return func(this, a_updateData);
 	}
 }

--- a/src/RE/I/Inventory.cpp
+++ b/src/RE/I/Inventory.cpp
@@ -5,7 +5,7 @@ namespace RE
 	BSTEventSource<Inventory::Event>* Inventory::GetEventSource()
 	{
 		using func_t = decltype(&Inventory::GetEventSource);
-		REL::Relocation<func_t> func{ Offset::Inventory::GetEventSource };
+		static REL::Relocation<func_t> func{ Offset::Inventory::GetEventSource };
 		return func();
 	}
 }

--- a/src/RE/I/Inventory3DManager.cpp
+++ b/src/RE/I/Inventory3DManager.cpp
@@ -11,49 +11,49 @@ namespace RE
 	void Inventory3DManager::Begin3D(INTERFACE_LIGHT_SCHEME a_scheme)
 	{
 		using func_t = decltype(&Inventory3DManager::Begin3D);
-		REL::Relocation<func_t> func{ RELOCATION_ID(50881, 51754) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(50881, 51754) };
 		return func(this, a_scheme);
 	}
 
 	void Inventory3DManager::End3D()
 	{
 		using func_t = decltype(&Inventory3DManager::End3D);
-		REL::Relocation<func_t> func{ RELOCATION_ID(50883, 51756) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(50883, 51756) };
 		return func(this);
 	}
 
 	void Inventory3DManager::LoadInventoryItem(InventoryEntryData* a_objDesc)
 	{
 		using func_t = void (*)(Inventory3DManager*, InventoryEntryData*);
-		REL::Relocation<func_t> func{ RELOCATION_ID(50884, 51757) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(50884, 51757) };
 		return func(this, a_objDesc);
 	}
 
 	void Inventory3DManager::LoadInventoryItem(TESBoundObject* a_object, ExtraDataList* a_extraDataList)
 	{
 		using func_t = void (*)(Inventory3DManager*, TESBoundObject*, ExtraDataList*);
-		REL::Relocation<func_t> func{ RELOCATION_ID(50885, 51758) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(50885, 51758) };
 		return func(this, a_object, a_extraDataList);
 	}
 
 	void Inventory3DManager::Render()
 	{
 		using func_t = decltype(&Inventory3DManager::Render);
-		REL::Relocation<func_t> func{ RELOCATION_ID(50882, 51755) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(50882, 51755) };
 		return func(this);
 	}
 
 	bool Inventory3DManager::ToggleItemZoom()
 	{
 		using func_t = decltype(&Inventory3DManager::ToggleItemZoom);
-		REL::Relocation<func_t> func{ RELOCATION_ID(50887, 51760) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(50887, 51760) };
 		return func(this);
 	}
 
 	void Inventory3DManager::UnloadInventoryItem()
 	{
 		using func_t = decltype(&Inventory3DManager::UnloadInventoryItem);
-		REL::Relocation<func_t> func{ RELOCATION_ID(50886, 51759) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(50886, 51759) };
 		return func(this);
 	}
 }

--- a/src/RE/I/InventoryChanges.cpp
+++ b/src/RE/I/InventoryChanges.cpp
@@ -30,119 +30,119 @@ namespace RE
 	TESObjectARMO* InventoryChanges::GetArmorInSlot(std::int32_t a_slot)
 	{
 		using func_t = decltype(&InventoryChanges::GetArmorInSlot);
-		REL::Relocation<func_t> func{ RELOCATION_ID(15873, 16113) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(15873, 16113) };
 		return func(this, a_slot);
 	}
 
 	float InventoryChanges::GetInventoryWeight()
 	{
 		using func_t = decltype(&InventoryChanges::GetInventoryWeight);
-		REL::Relocation<func_t> func{ RELOCATION_ID(15883, 16123) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(15883, 16123) };
 		return func(this);
 	}
 
 	std::uint16_t InventoryChanges::GetNextUniqueID()
 	{
 		using func_t = decltype(&InventoryChanges::GetNextUniqueID);
-		REL::Relocation<func_t> func{ Offset::InventoryChanges::GetNextUniqueID };
+		static REL::Relocation<func_t> func{ Offset::InventoryChanges::GetNextUniqueID };
 		return func(this);
 	}
 
 	std::uint32_t InventoryChanges::GetWornMask()
 	{
 		using func_t = decltype(&InventoryChanges::GetWornMask);
-		REL::Relocation<func_t> func{ RELOCATION_ID(15806, 16044) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(15806, 16044) };
 		return func(this);
 	}
 
 	void InventoryChanges::RemoveFavorite(InventoryEntryData* a_entry, ExtraDataList* a_itemList)
 	{
 		using func_t = decltype(&InventoryChanges::RemoveFavorite);
-		REL::Relocation<func_t> func{ RELOCATION_ID(15859, 16099) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(15859, 16099) };
 		return func(this, a_entry, a_itemList);
 	}
 
 	void InventoryChanges::RemoveAllItems(TESObjectREFR* a_ref, TESObjectREFR* a_moveToRef, bool a_arg4, bool a_keepOwnership, bool a_arg6)
 	{
 		using func_t = decltype(&InventoryChanges::RemoveAllItems);
-		REL::Relocation<func_t> func{ RELOCATION_ID(15878, 441567) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(15878, 441567) };
 		return func(this, a_ref, a_moveToRef, a_arg4, a_keepOwnership, a_arg6);
 	}
 
 	void InventoryChanges::SendContainerChangedEvent(ExtraDataList* a_itemExtraList, TESObjectREFR* a_fromRefr, TESForm* a_item, std::int32_t a_count)
 	{
 		using func_t = decltype(&InventoryChanges::SendContainerChangedEvent);
-		REL::Relocation<func_t> func{ Offset::InventoryChanges::SendContainerChangedEvent };
+		static REL::Relocation<func_t> func{ Offset::InventoryChanges::SendContainerChangedEvent };
 		return func(this, a_itemExtraList, a_fromRefr, a_item, a_count);
 	}
 
 	void InventoryChanges::SetFavorite(InventoryEntryData* a_entry, ExtraDataList* a_itemList)
 	{
 		using func_t = decltype(&InventoryChanges::SetFavorite);
-		REL::Relocation<func_t> func{ RELOCATION_ID(15858, 16098) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(15858, 16098) };
 		return func(this, a_entry, a_itemList);
 	}
 
 	void InventoryChanges::SetUniqueID(ExtraDataList* a_itemList, TESForm* a_oldForm, TESForm* a_newForm)
 	{
 		using func_t = decltype(&InventoryChanges::SetUniqueID);
-		REL::Relocation<func_t> func{ Offset::InventoryChanges::SetUniqueID };
+		static REL::Relocation<func_t> func{ Offset::InventoryChanges::SetUniqueID };
 		return func(this, a_itemList, a_oldForm, a_newForm);
 	}
 
 	void InventoryChanges::VisitInventory(IItemChangeVisitor& visitor)
 	{
 		using func_t = decltype(&InventoryChanges::VisitInventory);
-		REL::Relocation<func_t> func{ RELOCATION_ID(15855, 16095) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(15855, 16095) };
 		return func(this, visitor);
 	}
 
 	void InventoryChanges::VisitWornItems(IItemChangeVisitor& visitor)
 	{
 		using func_t = decltype(&InventoryChanges::VisitWornItems);
-		REL::Relocation<func_t> func{ RELOCATION_ID(15856, 16096) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(15856, 16096) };
 		return func(this, visitor);
 	}
 
 	void InventoryChanges::InitFromContainerExtra()
 	{
 		using func_t = decltype(&InventoryChanges::InitFromContainerExtra);
-		REL::Relocation<func_t> func{ RELOCATION_ID(15890, 16130) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(15890, 16130) };
 		return func(this);
 	}
 
 	void InventoryChanges::InitLeveledItems()
 	{
 		using func_t = decltype(&InventoryChanges::InitLeveledItems);
-		REL::Relocation<func_t> func{ RELOCATION_ID(15889, 16129) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(15889, 16129) };
 		return func(this);
 	}
 
 	void InventoryChanges::InitOutfitItems(BGSOutfit* a_outfit, std::uint16_t a_npcLevel)
 	{
 		using func_t = decltype(&InventoryChanges::InitOutfitItems);
-		REL::Relocation<func_t> func{ RELOCATION_ID(15833, 16072) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(15833, 16072) };
 		return func(this, a_outfit, a_npcLevel);
 	}
 
 	void InventoryChanges::InitScripts()
 	{
 		using func_t = decltype(&InventoryChanges::InitScripts);
-		REL::Relocation<func_t> func{ RELOCATION_ID(15829, 16068) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(15829, 16068) };
 		return func(this);
 	}
 
 	InventoryChanges* InventoryChanges::Ctor(TESObjectREFR* a_ref)
 	{
 		using func_t = decltype(&InventoryChanges::Ctor);
-		REL::Relocation<func_t> func{ RELOCATION_ID(15812, 16050) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(15812, 16050) };
 		return func(this, a_ref);
 	}
 
 	void InventoryChanges::Dtor()
 	{
 		using func_t = decltype(&InventoryChanges::Dtor);
-		REL::Relocation<func_t> func{ RELOCATION_ID(15813, 16051) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(15813, 16051) };
 		return func(this);
 	}
 }

--- a/src/RE/I/InventoryEntryData.cpp
+++ b/src/RE/I/InventoryEntryData.cpp
@@ -98,7 +98,7 @@ namespace RE
 	EnchantmentItem* InventoryEntryData::GetEnchantment() const
 	{
 		using func_t = decltype(&InventoryEntryData::GetEnchantment);
-		REL::Relocation<func_t> func{ RELOCATION_ID(15788, 16026) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(15788, 16026) };
 		return func(this);
 	}
 
@@ -180,7 +180,7 @@ namespace RE
 	std::int32_t InventoryEntryData::GetValue() const
 	{
 		using func_t = decltype(&InventoryEntryData::GetValue);
-		REL::Relocation<func_t> func{ RELOCATION_ID(15757, 15995) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(15757, 15995) };
 		return func(this);
 	}
 
@@ -259,14 +259,14 @@ namespace RE
 	void InventoryEntryData::PoisonObject(AlchemyItem* a_alchItem, std::uint32_t a_count)
 	{
 		using func_t = decltype(&InventoryEntryData::PoisonObject);
-		REL::Relocation<func_t> func{ RELOCATION_ID(15786, 16024) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(15786, 16024) };
 		return func(this, a_alchItem, a_count);
 	}
 
 	bool InventoryEntryData::IsOwnedBy_Impl(Actor* a_testOwner, TESForm* a_itemOwner, bool a_defaultTo)
 	{
 		using func_t = decltype(&InventoryEntryData::IsOwnedBy_Impl);
-		REL::Relocation<func_t> func{ RELOCATION_ID(15782, 16020) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(15782, 16020) };
 		return func(this, a_testOwner, a_itemOwner, a_defaultTo);
 	}
 }

--- a/src/RE/I/ItemCrafted.cpp
+++ b/src/RE/I/ItemCrafted.cpp
@@ -5,7 +5,7 @@ namespace RE
 	BSTEventSource<ItemCrafted::Event>* ItemCrafted::GetEventSource()
 	{
 		using func_t = decltype(&ItemCrafted::GetEventSource);
-		REL::Relocation<func_t> func{ Offset::ItemCrafted::GetEventSource };
+		static REL::Relocation<func_t> func{ Offset::ItemCrafted::GetEventSource };
 		return func();
 	}
 }

--- a/src/RE/I/ItemHarvested.cpp
+++ b/src/RE/I/ItemHarvested.cpp
@@ -5,7 +5,7 @@ namespace RE
 	BSTEventSource<TESHarvestedEvent::ItemHarvested>* TESHarvestedEvent::GetEventSource()
 	{
 		using func_t = decltype(&TESHarvestedEvent::GetEventSource);
-		REL::Relocation<func_t> func{ RELOCATION_ID(14704, 14875) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(14704, 14875) };
 		return func();
 	}
 }

--- a/src/RE/I/ItemList.cpp
+++ b/src/RE/I/ItemList.cpp
@@ -39,7 +39,7 @@ namespace RE
 	void ItemList::Update_Impl(TESObjectREFR* a_owner)
 	{
 		using func_t = decltype(&ItemList::Update_Impl);
-		REL::Relocation<func_t> func{ Offset::ItemList::Update };
+		static REL::Relocation<func_t> func{ Offset::ItemList::Update };
 		return func(this, a_owner);
 	}
 }

--- a/src/RE/I/ItemsPickpocketed.cpp
+++ b/src/RE/I/ItemsPickpocketed.cpp
@@ -5,7 +5,7 @@ namespace RE
 	BSTEventSource<ItemsPickpocketed::Event>* ItemsPickpocketed::GetEventSource()
 	{
 		using func_t = decltype(&ItemsPickpocketed::GetEventSource);
-		REL::Relocation<func_t> func{ Offset::ItemsPickpocketed::GetEventSource };
+		static REL::Relocation<func_t> func{ Offset::ItemsPickpocketed::GetEventSource };
 		return func();
 	}
 

--- a/src/RE/L/LevelIncrease.cpp
+++ b/src/RE/L/LevelIncrease.cpp
@@ -5,7 +5,7 @@ namespace RE
 	BSTEventSource<LevelIncrease::Event>* LevelIncrease::GetEventSource()
 	{
 		using func_t = decltype(&LevelIncrease::GetEventSource);
-		REL::Relocation<func_t> func{ RELOCATION_ID(39247, 40319) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(39247, 40319) };
 		return func();
 	}
 }

--- a/src/RE/L/LocalMapCamera.cpp
+++ b/src/RE/L/LocalMapCamera.cpp
@@ -45,14 +45,14 @@ namespace RE
 	void LocalMapCamera::SetNorthRotation(float a_northRotation)
 	{
 		using func_t = decltype(&LocalMapCamera::SetNorthRotation);
-		REL::Relocation<func_t> func{ Offset::LocalMapCamera::SetNorthRotation };
+		static REL::Relocation<func_t> func{ Offset::LocalMapCamera::SetNorthRotation };
 		return func(this, a_northRotation);
 	}
 
 	LocalMapCamera* LocalMapCamera::Ctor(float a_zRotation)
 	{
 		using func_t = decltype(&LocalMapCamera::Ctor);
-		REL::Relocation<func_t> func{ Offset::LocalMapCamera::Ctor };
+		static REL::Relocation<func_t> func{ Offset::LocalMapCamera::Ctor };
 		return func(this, a_zRotation);
 	}
 }

--- a/src/RE/L/LocationCleared.cpp
+++ b/src/RE/L/LocationCleared.cpp
@@ -5,7 +5,7 @@ namespace RE
 	BSTEventSource<LocationCleared::Event>* LocationCleared::GetEventSource()
 	{
 		using func_t = decltype(&LocationCleared::GetEventSource);
-		REL::Relocation<func_t> func{ RELOCATION_ID(18046, 18435) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(18046, 18435) };
 		return func();
 	}
 }

--- a/src/RE/L/LocationDiscovery.cpp
+++ b/src/RE/L/LocationDiscovery.cpp
@@ -5,7 +5,7 @@ namespace RE
 	BSTEventSource<LocationDiscovery::Event>* LocationDiscovery::GetEventSource()
 	{
 		using func_t = decltype(&LocationDiscovery::GetEventSource);
-		REL::Relocation<func_t> func{ RELOCATION_ID(40056, 41067) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(40056, 41067) };
 		return func();
 	}
 }

--- a/src/RE/L/LooseFileStream.cpp
+++ b/src/RE/L/LooseFileStream.cpp
@@ -16,7 +16,7 @@ namespace RE
 		LooseFileStream* LooseFileStream::Ctor(const BSFixedString& a_prefix, const BSFixedString& a_dirName, const BSFixedString& a_fileName, std::uint32_t a_fileSize, bool a_readOnly, Location* a_location)
 		{
 			using func_t = decltype(&LooseFileStream::Ctor);
-			REL::Relocation<func_t> func{ Offset::LooseFileStream::Ctor };
+			static REL::Relocation<func_t> func{ Offset::LooseFileStream::Ctor };
 			return func(this, a_prefix, a_dirName, a_fileName, a_fileSize, a_readOnly, a_location);
 		}
 #endif

--- a/src/RE/M/MagicCaster.cpp
+++ b/src/RE/M/MagicCaster.cpp
@@ -9,49 +9,49 @@ namespace RE
 	MagicTarget* MagicCaster::FindPickTarget(NiPoint3& a_targetLocation, TESObjectCELL** a_targetCell, bhkPickData& a_pickData)
 	{
 		using func_t = decltype(&MagicCaster::FindPickTarget);
-		REL::Relocation<func_t> func{ RELOCATION_ID(33676, 34456) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(33676, 34456) };
 		return func(this, a_targetLocation, a_targetCell, a_pickData);
 	}
 
 	bool MagicCaster::FindTargets(float a_effectivenessMult, std::uint32_t& a_targetCount, TESBoundObject* a_source, bool a_loadCast, bool a_adjustOnlyHostileEffectiveness)
 	{
 		using func_t = decltype(&MagicCaster::FindTargets);
-		REL::Relocation<func_t> func{ RELOCATION_ID(33632, 34410) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(33632, 34410) };
 		return func(this, a_effectivenessMult, a_targetCount, a_source, a_loadCast, a_adjustOnlyHostileEffectiveness);
 	}
 
 	void MagicCaster::FinishCast()
 	{
 		using func_t = decltype(&MagicCaster::FinishCast);
-		REL::Relocation<func_t> func{ RELOCATION_ID(33657, 34435) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(33657, 34435) };
 		return func(this);
 	}
 
 	float MagicCaster::GetCurrentSpellCost()
 	{
 		using func_t = decltype(&MagicCaster::GetCurrentSpellCost);
-		REL::Relocation<func_t> func{ RELOCATION_ID(33426, 34204) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(33426, 34204) };
 		return func(this);
 	}
 
 	void MagicCaster::InterruptCast(bool a_refund)
 	{
 		using func_t = decltype(&MagicCaster::InterruptCast);
-		REL::Relocation<func_t> func{ RELOCATION_ID(33630, 34408) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(33630, 34408) };
 		return func(this, a_refund);
 	}
 
 	void MagicCaster::PlayReleaseSound(MagicItem* a_item)
 	{
 		using func_t = decltype(&MagicCaster::PlayReleaseSound);
-		REL::Relocation<func_t> func{ RELOCATION_ID(33675, 34448) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(33675, 34448) };
 		return func(this, a_item);
 	}
 
 	void MagicCaster::SetCurrentSpell(MagicItem* a_item)
 	{
 		using func_t = decltype(&MagicCaster::SetCurrentSpell);
-		REL::Relocation<func_t> func{ RELOCATION_ID(33644, 34422) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(33644, 34422) };
 		return func(this, a_item);
 	}
 
@@ -84,7 +84,7 @@ namespace RE
 	void MagicCaster::UpdateImpl(float a_delta)
 	{
 		using func_t = decltype(&MagicCaster::UpdateImpl);
-		REL::Relocation<func_t> func{ RELOCATION_ID(33622, 34400) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(33622, 34400) };
 		return func(this, a_delta);
 	}
 }

--- a/src/RE/M/MagicFavorites.cpp
+++ b/src/RE/M/MagicFavorites.cpp
@@ -11,14 +11,14 @@ namespace RE
 	void MagicFavorites::RemoveFavorite(TESForm* a_form)
 	{
 		using func_t = decltype(&MagicFavorites::RemoveFavorite);
-		REL::Relocation<func_t> func{ RELOCATION_ID(51122, 52005) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(51122, 52005) };
 		return func(this, a_form);
 	}
 
 	void MagicFavorites::SetFavorite(TESForm* a_form)
 	{
 		using func_t = decltype(&MagicFavorites::SetFavorite);
-		REL::Relocation<func_t> func{ RELOCATION_ID(51121, 52004) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(51121, 52004) };
 		return func(this, a_form);
 	}
 }

--- a/src/RE/M/MagicItem.cpp
+++ b/src/RE/M/MagicItem.cpp
@@ -22,21 +22,21 @@ namespace RE
 	EffectSetting* MagicItem::GetAVEffect() const
 	{
 		using func_t = decltype(&MagicItem::GetAVEffect);
-		REL::Relocation<func_t> func{ RELOCATION_ID(11194, 11302) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(11194, 11302) };
 		return func(this);
 	}
 
 	Effect* MagicItem::GetCostliestEffectItem(MagicSystem::Delivery a_delivery, bool a_positiveArea) const
 	{
 		using func_t = decltype(&MagicItem::GetCostliestEffectItem);
-		REL::Relocation<func_t> func{ Offset::MagicItem::GetCostliestEffectItem };
+		static REL::Relocation<func_t> func{ Offset::MagicItem::GetCostliestEffectItem };
 		return func(this, a_delivery, a_positiveArea);
 	}
 
 	float MagicItem::CalculateCost(Actor* a_caster) const
 	{
 		using func_t = decltype(&MagicItem::CalculateTotalGoldValue);
-		REL::Relocation<func_t> func{ Offset::MagicItem::CalculateCost };
+		static REL::Relocation<func_t> func{ Offset::MagicItem::CalculateCost };
 		return func(this, a_caster);
 	}
 
@@ -55,21 +55,21 @@ namespace RE
 	std::int32_t MagicItem::GetLargestArea() const
 	{
 		using func_t = decltype(&MagicItem::GetLargestArea);
-		REL::Relocation<func_t> func{ RELOCATION_ID(11219, 11338) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(11219, 11338) };
 		return func(this);
 	}
 
 	std::uint32_t MagicItem::GetLongestDuration() const
 	{
 		using func_t = decltype(&MagicItem::GetLongestDuration);
-		REL::Relocation<func_t> func{ RELOCATION_ID(11218, 11337) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(11218, 11337) };
 		return func(this);
 	}
 
 	bool MagicItem::HasEffect(EffectArchetype a_archetype)
 	{
 		using func_t = decltype(&MagicItem::HasEffect);
-		REL::Relocation<func_t> func{ RELOCATION_ID(11207, 11315) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(11207, 11315) };
 		return func(this, a_archetype);
 	}
 
@@ -81,14 +81,14 @@ namespace RE
 	bool MagicItem::IsPermanent() const
 	{
 		using func_t = decltype(&MagicItem::IsPermanent);
-		REL::Relocation<func_t> func{ RELOCATION_ID(11183, 11290) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(11183, 11290) };
 		return func(this);
 	}
 
 	void MagicItem::Traverse(MagicItemTraversalFunctor& a_visitor) const
 	{
 		using func_t = decltype(&MagicItem::Traverse);
-		REL::Relocation<func_t> func{ RELOCATION_ID(11222, 11341) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(11222, 11341) };
 		return func(this, a_visitor);
 	}
 }

--- a/src/RE/M/MagicItemDataCollector.cpp
+++ b/src/RE/M/MagicItemDataCollector.cpp
@@ -23,7 +23,7 @@ namespace RE
 	BSContainer::ForEachResult MagicItemDataCollector::operator()(Effect* a_effect)
 	{
 		using func_t = decltype(&MagicItemDataCollector::operator());
-		REL::Relocation<func_t> func{ RELOCATION_ID(33834, 34626) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(33834, 34626) };
 		return func(this, a_effect);
 	}
 }

--- a/src/RE/M/MagicSystem.cpp
+++ b/src/RE/M/MagicSystem.cpp
@@ -9,28 +9,28 @@ namespace RE
 		const char* GetCannotCastString(MagicSystem::CannotCastReason a_reason)
 		{
 			using func_t = decltype(&MagicSystem::GetCannotCastString);
-			REL::Relocation<func_t> func{ RELOCATION_ID(11295, 11423) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(11295, 11423) };
 			return func(a_reason);
 		}
 
 		float GetMagicCasterTargetUpdateInterval()
 		{
 			using func_t = decltype(&MagicSystem::GetMagicCasterTargetUpdateInterval);
-			REL::Relocation<func_t> func{ RELOCATION_ID(11294, 11422) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(11294, 11422) };
 			return func();
 		}
 
 		BGSSoundDescriptorForm* GetMagicFailureSound(MagicSystem::SpellType a_type)
 		{
 			using func_t = decltype(&MagicSystem::GetMagicFailureSound);
-			REL::Relocation<func_t> func{ RELOCATION_ID(11286, 11411) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(11286, 11411) };
 			return func(a_type);
 		}
 
 		void GetMagicItemDescription(BSString& a_out, MagicItem* a_magicItem, const char* a_beginTagFormat, const char* a_endTagFormat)
 		{
 			using func_t = decltype(&MagicSystem::GetMagicItemDescription);
-			REL::Relocation<func_t> func{ RELOCATION_ID(11299, 11427) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(11299, 11427) };
 			return func(a_out, a_magicItem, a_beginTagFormat, a_endTagFormat);
 		}
 	}

--- a/src/RE/M/MagicTarget.cpp
+++ b/src/RE/M/MagicTarget.cpp
@@ -10,7 +10,7 @@ namespace RE
 	bool MagicTarget::DispelEffect(MagicItem* a_spell, BSPointerHandle<Actor>& a_caster, ActiveEffect* a_effect)
 	{
 		using func_t = decltype(&MagicTarget::DispelEffect);
-		REL::Relocation<func_t> func{ RELOCATION_ID(33721, 34505) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(33721, 34505) };
 		return func(this, a_spell, a_caster, a_effect);
 	}
 
@@ -63,21 +63,21 @@ namespace RE
 	bool MagicTarget::HasMagicEffect(EffectSetting* a_effect)
 	{
 		using func_t = decltype(&MagicTarget::HasMagicEffect);
-		REL::Relocation<func_t> func{ Offset::MagicTarget::HasMagicEffect };
+		static REL::Relocation<func_t> func{ Offset::MagicTarget::HasMagicEffect };
 		return func(this, a_effect);
 	}
 
 	bool MagicTarget::HasMagicEffectWithKeyword(BGSKeyword* a_keyword, std::uint64_t a_arg2)
 	{
 		using func_t = decltype(&MagicTarget::HasMagicEffectWithKeyword);
-		REL::Relocation<func_t> func{ RELOCATION_ID(33734, 34518) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(33734, 34518) };
 		return func(this, a_keyword, a_arg2);
 	}
 
 	void MagicTarget::VisitEffects(ForEachActiveEffectVisitor& visitor)
 	{
 		using func_t = decltype(&MagicTarget::VisitEffects);
-		REL::Relocation<func_t> func{ RELOCATION_ID(33756, 34540) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(33756, 34540) };
 		return func(this, visitor);
 	}
 }

--- a/src/RE/M/MagicUtilities.cpp
+++ b/src/RE/M/MagicUtilities.cpp
@@ -7,35 +7,35 @@ namespace RE
 		ActorValue GetAssociatedResource(MagicItem* a_item, MagicSystem::CastingSource a_castingSource)
 		{
 			using func_t = decltype(&GetAssociatedResource);
-			REL::Relocation<func_t> func{ RELOCATION_ID(33817, 34609) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(33817, 34609) };
 			return func(a_item, a_castingSource);
 		}
 
 		MagicSystem::CannotCastReason GetAssociatedResourceReason(MagicItem* a_item, MagicSystem::CastingSource a_castingSource)
 		{
 			using func_t = decltype(&GetAssociatedResourceReason);
-			REL::Relocation<func_t> func{ RELOCATION_ID(33818, 34610) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(33818, 34610) };
 			return func(a_item, a_castingSource);
 		}
 
 		bool UsesResourceOnRelease(MagicItem* a_item, MagicSystem::CastingSource a_castingSource)
 		{
 			using func_t = decltype(&UsesResourceOnRelease);
-			REL::Relocation<func_t> func{ RELOCATION_ID(33821, 34613) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(33821, 34613) };
 			return func(a_item, a_castingSource);
 		}
 
 		bool UsesResourceWhileCasting(MagicItem* a_item, MagicSystem::CastingSource a_castingSource)
 		{
 			using func_t = decltype(&UsesResourceWhileCasting);
-			REL::Relocation<func_t> func{ RELOCATION_ID(33820, 34612) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(33820, 34612) };
 			return func(a_item, a_castingSource);
 		}
 
 		bool UsesResourceWhileCharging(MagicItem* a_item, MagicSystem::CastingSource a_castingSource)
 		{
 			using func_t = decltype(&UsesResourceWhileCharging);
-			REL::Relocation<func_t> func{ RELOCATION_ID(33819, 34611) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(33819, 34611) };
 			return func(a_item, a_castingSource);
 		}
 	}

--- a/src/RE/M/Main.cpp
+++ b/src/RE/M/Main.cpp
@@ -20,7 +20,7 @@ namespace RE
 	NiCamera* Main::WorldRootCamera()
 	{
 		using func_t = decltype(&Main::WorldRootCamera);
-		REL::Relocation<func_t> func{ RELOCATION_ID(35601, 36609) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(35601, 36609) };
 		return func();
 	}
 
@@ -33,7 +33,7 @@ namespace RE
 	void Main::SetActive(bool a_active)
 	{
 		using func_t = decltype(&Main::SetActive);
-		REL::Relocation<func_t> func{ RELOCATION_ID(35598, 36606) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(35598, 36606) };
 		return func(this, a_active);
 	}
 }

--- a/src/RE/M/Misc.cpp
+++ b/src/RE/M/Misc.cpp
@@ -16,35 +16,35 @@ namespace RE
 	bool LookupReferenceByHandle_ActorImpl(const RefHandle& a_handle, NiPointer<Actor>& a_refrOut)
 	{
 		using func_t = decltype(&LookupReferenceByHandle_ActorImpl);
-		REL::Relocation<func_t> func{ Offset::LookupReferenceByHandle };
+		static REL::Relocation<func_t> func{ Offset::LookupReferenceByHandle };
 		return func(a_handle, a_refrOut);
 	}
 
 	bool LookupReferenceByHandle_RefrImpl(const RefHandle& a_handle, NiPointer<TESObjectREFR>& a_refrOut)
 	{
 		using func_t = decltype(&LookupReferenceByHandle_RefrImpl);
-		REL::Relocation<func_t> func{ Offset::LookupReferenceByHandle };
+		static REL::Relocation<func_t> func{ Offset::LookupReferenceByHandle };
 		return func(a_handle, a_refrOut);
 	}
 
 	void CreateMessage(const char* a_message, IMessageBoxCallback* a_callback, std::uint32_t a_arg3, std::uint32_t a_arg4, std::uint32_t a_arg5, const char* a_buttonText, const char* a_secondaryButtonText)
 	{
 		using func_t = decltype(&CreateMessage);
-		REL::Relocation<func_t> func{ RELOCATION_ID(51420, 52269) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(51420, 52269) };
 		return func(a_message, a_callback, a_arg3, a_arg4, a_arg5, a_buttonText, a_secondaryButtonText);
 	}
 
 	void CreateRefHandle(RefHandle& a_handleOut, TESObjectREFR* a_refTo)
 	{
 		using func_t = decltype(&CreateRefHandle);
-		REL::Relocation<func_t> func{ Offset::CreateRefHandle };
+		static REL::Relocation<func_t> func{ Offset::CreateRefHandle };
 		return func(a_handleOut, a_refTo);
 	}
 
 	void DebugNotification(const char* a_notification, const char* a_soundToPlay, bool a_cancelIfAlreadyQueued)
 	{
 		using func_t = decltype(&DebugNotification);
-		REL::Relocation<func_t> func{ Offset::DebugNotification };
+		static REL::Relocation<func_t> func{ Offset::DebugNotification };
 		return func(a_notification, a_soundToPlay, a_cancelIfAlreadyQueued);
 	}
 
@@ -56,7 +56,7 @@ namespace RE
 	float GetArmorFinalRating(RE::InventoryEntryData* a_armorEntryData, float a_armorPerks, float a_skillMultiplier)
 	{
 		using func_t = decltype(&GetArmorFinalRating);
-		REL::Relocation<func_t> func{ RELOCATION_ID(15779, 16017) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(15779, 16017) };
 		return func(a_armorEntryData, a_armorPerks, a_skillMultiplier);
 	}
 
@@ -98,14 +98,14 @@ namespace RE
 	void PlaySound(const char* a_editorID)
 	{
 		using func_t = decltype(&PlaySound);
-		REL::Relocation<func_t> func{ Offset::PlaySound };
+		static REL::Relocation<func_t> func{ Offset::PlaySound };
 		return func(a_editorID);
 	}
 
 	void ShakeCamera(float a_strength, const NiPoint3& a_position, float a_duration)
 	{
 		using func_t = decltype(&ShakeCamera);
-		REL::Relocation<func_t> func{ RELOCATION_ID(32275, 33012) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(32275, 33012) };
 		return func(a_strength, a_position, a_duration);
 	}
 }

--- a/src/RE/N/NativeFunctionBase.cpp
+++ b/src/RE/N/NativeFunctionBase.cpp
@@ -107,7 +107,7 @@ namespace RE
 				-> CallResult
 			{
 				using func_t = decltype(&NativeFunctionBase::Call);
-				REL::Relocation<func_t> func{ Offset::BSScript::NF_util::NativeFunctionBase::Call };
+				static REL::Relocation<func_t> func{ Offset::BSScript::NF_util::NativeFunctionBase::Call };
 				return func(this, a_stack, a_logger, a_vm, a_arg4);
 			}
 

--- a/src/RE/N/NiAVObject.cpp
+++ b/src/RE/N/NiAVObject.cpp
@@ -24,7 +24,7 @@ namespace RE
 	NiAVObject* NiAVObject::Clone()
 	{
 		using func_t = decltype(&NiAVObject::Clone);
-		REL::Relocation<func_t> func{ RELOCATION_ID(68835, 70187) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(68835, 70187) };
 		return func(this);
 	}
 
@@ -54,7 +54,7 @@ namespace RE
 	bhkCollisionObject* NiAVObject::GetCollisionObject() const
 	{
 		using func_t = decltype(&NiAVObject::GetCollisionObject);
-		REL::Relocation<func_t> func{ RELOCATION_ID(25482, 26022) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(25482, 26022) };
 		return func(this);
 	}
 
@@ -155,7 +155,7 @@ namespace RE
 	void NiAVObject::RemoveDecals()
 	{
 		using func_t = decltype(&NiAVObject::RemoveDecals);
-		REL::Relocation<func_t> func{ RELOCATION_ID(15547, 15723) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(15547, 15723) };
 		return func(this);
 	}
 
@@ -167,21 +167,21 @@ namespace RE
 	void NiAVObject::SetCollisionLayer(COL_LAYER a_collisionLayer)
 	{
 		using func_t = decltype(&NiAVObject::SetCollisionLayer);
-		REL::Relocation<func_t> func{ RELOCATION_ID(76170, 77998) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(76170, 77998) };
 		return func(this, a_collisionLayer);
 	}
 
 	void NiAVObject::SetCollisionLayerAndGroup(COL_LAYER a_collisionLayer, std::uint32_t a_group)
 	{
 		using func_t = decltype(&NiAVObject::SetCollisionLayerAndGroup);
-		REL::Relocation<func_t> func{ RELOCATION_ID(76171, 77999) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(76171, 77999) };
 		return func(this, a_collisionLayer, a_group);
 	}
 
 	bool NiAVObject::SetMotionType(hkpMotion::MotionType a_motionType, bool a_recurse, bool a_force, bool a_allowActivate)
 	{
 		using func_t = decltype(&NiAVObject::SetMotionType);
-		REL::Relocation<func_t> func{ Offset::NiAVObject::SetMotionType };
+		static REL::Relocation<func_t> func{ Offset::NiAVObject::SetMotionType };
 		return func(this, a_motionType, a_recurse, a_force, a_allowActivate);
 	}
 
@@ -249,7 +249,7 @@ namespace RE
 	void NiAVObject::Update(NiUpdateData& a_data)
 	{
 		using func_t = decltype(&NiAVObject::Update);
-		REL::Relocation<func_t> func{ Offset::NiAVObject::Update };
+		static REL::Relocation<func_t> func{ Offset::NiAVObject::Update };
 		return func(this, a_data);
 	}
 
@@ -326,7 +326,7 @@ namespace RE
 	void NiAVObject::UpdateRigidConstraints(bool a_enable, std::uint8_t a_arg2, std::uint32_t a_arg3)
 	{
 		using func_t = decltype(&NiAVObject::UpdateRigidConstraints);
-		REL::Relocation<func_t> func{ RELOCATION_ID(76271, 78103) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(76271, 78103) };
 		return func(this, a_enable, a_arg2, a_arg3);
 	}
 }

--- a/src/RE/N/NiCamera.cpp
+++ b/src/RE/N/NiCamera.cpp
@@ -5,7 +5,7 @@ namespace RE
 	bool NiCamera::BoundInFrustum(const NiBound& a_bound, NiCamera* a_camera)
 	{
 		using func_t = decltype(&NiCamera::BoundInFrustum);
-		REL::Relocation<func_t> func{ RELOCATION_ID(15671, 15899) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(15671, 15899) };
 		return func(a_bound, a_camera);
 	}
 
@@ -31,7 +31,7 @@ namespace RE
 	bool NiCamera::WindowPointToRay(std::int32_t a_x, std::int32_t a_y, NiPoint3& a_origin, NiPoint3& a_dir, float a_windowWidth, float a_windowHeight)
 	{
 		using func_t = decltype(&NiCamera::WindowPointToRay);
-		REL::Relocation<func_t> func{ RELOCATION_ID(69263, 70630) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(69263, 70630) };
 		return func(this, a_x, a_y, a_origin, a_dir, a_windowWidth, a_windowHeight);
 	}
 
@@ -43,7 +43,7 @@ namespace RE
 	bool NiCamera::WorldPtToScreenPt3(const float a_matrix[4][4], const NiRect<float>& a_port, const NiPoint3& a_point, float& a_xOut, float& a_yOut, float& a_zOut, float a_zeroTolerance)
 	{
 		using func_t = bool (*)(const float[4][4], const NiRect<float>&, const NiPoint3&, float&, float&, float&, float);
-		REL::Relocation<func_t> func{ Offset::NiCamera::WorldPtToScreenPt3 };
+		static REL::Relocation<func_t> func{ Offset::NiCamera::WorldPtToScreenPt3 };
 		return func(a_matrix, a_port, a_point, a_xOut, a_yOut, a_zOut, a_zeroTolerance);
 	}
 }

--- a/src/RE/N/NiControllerSequence.cpp
+++ b/src/RE/N/NiControllerSequence.cpp
@@ -5,14 +5,14 @@ namespace RE
 	bool NiControllerSequence::Activate(std::uint8_t a_interpIndex, bool a_maxOffset, float a_seqWeight, float a_easeInTime, NiControllerSequence* a_partnerSequence, bool a_transition)
 	{
 		using func_t = decltype(&NiControllerSequence::Activate);
-		REL::Relocation<func_t> func{ RELOCATION_ID(70882, 72463) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(70882, 72463) };
 		return func(this, a_interpIndex, a_maxOffset, a_seqWeight, a_easeInTime, a_partnerSequence, a_transition);
 	}
 
 	void NiControllerSequence::SetPhase(float a_phase, bool a_arg2)
 	{
 		using func_t = decltype(&NiControllerSequence::SetPhase);
-		REL::Relocation<func_t> func{ RELOCATION_ID(70860, 72439) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(70860, 72439) };
 		return func(this, a_phase, a_arg2);
 	}
 }

--- a/src/RE/N/NiNode.cpp
+++ b/src/RE/N/NiNode.cpp
@@ -45,7 +45,7 @@ namespace RE
 	NiNode* NiNode::Ctor(std::uint16_t a_arrBuffLen)
 	{
 		using func_t = decltype(&NiNode::Ctor);
-		REL::Relocation<func_t> func{ Offset::NiNode::Ctor };
+		static REL::Relocation<func_t> func{ Offset::NiNode::Ctor };
 		return func(this, a_arrBuffLen);
 	}
 }

--- a/src/RE/N/NiObject.cpp
+++ b/src/RE/N/NiObject.cpp
@@ -24,14 +24,14 @@ namespace RE
 	void NiObject::ProcessClone(NiCloningProcess& a_cloning)
 	{
 		using func_t = decltype(&NiObject::ProcessClone);
-		REL::Relocation<func_t> func{ RELOCATION_ID(68838, 70190) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(68838, 70190) };
 		return func(this, a_cloning);
 	}
 
 	void NiObject::CreateDeepCopy(NiPointer<NiObject>& a_object)
 	{
 		using func_t = decltype(&NiObject::CreateDeepCopy);
-		REL::Relocation<func_t> func{ RELOCATION_ID(68839, 70191) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(68839, 70191) };
 		return func(this, a_object);
 	}
 }

--- a/src/RE/N/NiSkinInstance.cpp
+++ b/src/RE/N/NiSkinInstance.cpp
@@ -5,7 +5,7 @@ namespace RE
 	NiSkinInstance* NiSkinInstance::Create()
 	{
 		using func_t = decltype(&NiSkinInstance::Create);
-		REL::Relocation<func_t> func{ Offset::NiSkinInstance::Ctor };
+		static REL::Relocation<func_t> func{ Offset::NiSkinInstance::Ctor };
 		return func();
 	}
 }

--- a/src/RE/N/NiTimeController.cpp
+++ b/src/RE/N/NiTimeController.cpp
@@ -11,91 +11,91 @@ namespace RE
 	void NiTimeController::LoadBinary(NiStream& a_stream)
 	{
 		using func_t = decltype(&NiTimeController::LoadBinary);
-		REL::Relocation<func_t> func{ RELOCATION_ID(69433, 70810) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(69433, 70810) };
 		return func(this, a_stream);
 	}
 
 	void NiTimeController::LinkObject(NiStream& a_stream)
 	{
 		using func_t = decltype(&NiTimeController::LinkObject);
-		REL::Relocation<func_t> func{ RELOCATION_ID(69434, 70811) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(69434, 70811) };
 		return func(this, a_stream);
 	}
 
 	bool NiTimeController::RegisterStreamables(NiStream& a_stream)
 	{
 		using func_t = decltype(&NiTimeController::RegisterStreamables);
-		REL::Relocation<func_t> func{ RELOCATION_ID(69435, 70812) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(69435, 70812) };
 		return func(this, a_stream);
 	}
 
 	void NiTimeController::SaveBinary(NiStream& a_stream)
 	{
 		using func_t = decltype(&NiTimeController::SaveBinary);
-		REL::Relocation<func_t> func{ RELOCATION_ID(69436, 70813) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(69436, 70813) };
 		return func(this, a_stream);
 	}
 
 	bool NiTimeController::IsEqual(NiObject* a_object)
 	{
 		using func_t = decltype(&NiTimeController::IsEqual);
-		REL::Relocation<func_t> func{ RELOCATION_ID(69437, 70814) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(69437, 70814) };
 		return func(this, a_object);
 	}
 
 	void NiTimeController::ProcessClone(NiCloningProcess& a_cloning)
 	{
 		using func_t = decltype(&NiTimeController::ProcessClone);
-		REL::Relocation<func_t> func{ RELOCATION_ID(69449, 70826) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(69449, 70826) };
 		return func(this, a_cloning);
 	}
 
 	void NiTimeController::Start(float a_time)
 	{
 		using func_t = decltype(&NiTimeController::Start);
-		REL::Relocation<func_t> func{ RELOCATION_ID(69440, 70817) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(69440, 70817) };
 		return func(this, a_time);
 	}
 
 	void NiTimeController::Stop()
 	{
 		using func_t = decltype(&NiTimeController::Stop);
-		REL::Relocation<func_t> func{ RELOCATION_ID(69441, 70818) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(69441, 70818) };
 		return func(this);
 	}
 
 	void NiTimeController::SetTarget(NiObjectNET* a_target)
 	{
 		using func_t = decltype(&NiTimeController::SetTarget);
-		REL::Relocation<func_t> func{ RELOCATION_ID(69442, 70819) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(69442, 70819) };
 		return func(this, a_target);
 	}
 
 	float NiTimeController::ComputeScaledTime(float a_time)
 	{
 		using func_t = decltype(&NiTimeController::ComputeScaledTime);
-		REL::Relocation<func_t> func{ RELOCATION_ID(69447, 70824) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(69447, 70824) };
 		return func(this, a_time);
 	}
 
 	void NiTimeController::StartAnimations(NiObjectNET* a_target)
 	{
 		using func_t = decltype(&NiTimeController::StartAnimations);
-		REL::Relocation<func_t> func{ RELOCATION_ID(69444, 70821) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(69444, 70821) };
 		return func(a_target);
 	}
 
 	NiTimeController* NiTimeController::ctor()
 	{
 		using func_t = decltype(&NiTimeController::ctor);
-		REL::Relocation<func_t> func{ RELOCATION_ID(69438, 70815) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(69438, 70815) };
 		return func(this);
 	}
 
 	void NiTimeController::dtor()
 	{
 		using func_t = decltype(&NiTimeController::dtor);
-		REL::Relocation<func_t> func{ RELOCATION_ID(69439, 70816) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(69439, 70816) };
 		return func(this);
 	}
 }

--- a/src/RE/O/Object.cpp
+++ b/src/RE/O/Object.cpp
@@ -17,7 +17,7 @@ namespace RE
 		VMHandle Object::GetHandle() const
 		{
 			using func_t = decltype(&Object::GetHandle);
-			REL::Relocation<func_t> func{ RELOCATION_ID(97463, 104247) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(97463, 104247) };
 			return func(this);
 		}
 
@@ -46,14 +46,14 @@ namespace RE
 		void Object::IncRef()
 		{
 			using func_t = decltype(&Object::IncRef);
-			REL::Relocation<func_t> func{ RELOCATION_ID(97468, 104252) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(97468, 104252) };
 			return func(this);
 		}
 
 		std::uint32_t Object::DecRef()
 		{
 			using func_t = decltype(&Object::DecRef);
-			REL::Relocation<func_t> func{ RELOCATION_ID(97469, 104253) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(97469, 104253) };
 			return func(this);
 		}
 
@@ -114,7 +114,7 @@ namespace RE
 		void Object::Dtor()
 		{
 			using func_t = decltype(&Object::Dtor);
-			REL::Relocation<func_t> func{ RELOCATION_ID(97462, 104246) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(97462, 104246) };
 			return func(this);
 		}
 	}

--- a/src/RE/O/ObjectTypeInfo.cpp
+++ b/src/RE/O/ObjectTypeInfo.cpp
@@ -169,7 +169,7 @@ namespace RE
 		void ObjectTypeInfo::ReleaseData()
 		{
 			using func_t = decltype(&ObjectTypeInfo::ReleaseData);
-			REL::Relocation<func_t> func{ 97538 };
+			static REL::Relocation<func_t> func{ 97538 };
 			return func(this);
 		}
 	}

--- a/src/RE/O/ObjectiveState.cpp
+++ b/src/RE/O/ObjectiveState.cpp
@@ -5,7 +5,7 @@ namespace RE
 	BSTEventSource<ObjectiveState::Event>* ObjectiveState::GetEventSource()
 	{
 		using func_t = decltype(&ObjectiveState::GetEventSource);
-		REL::Relocation<func_t> func{ RELOCATION_ID(23486, 23951) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(23486, 23951) };
 		return func();
 	}
 }

--- a/src/RE/P/PlayerCamera.cpp
+++ b/src/RE/P/PlayerCamera.cpp
@@ -11,14 +11,14 @@ namespace RE
 	void PlayerCamera::ForceFirstPerson()
 	{
 		using func_t = decltype(&PlayerCamera::ForceFirstPerson);
-		REL::Relocation<func_t> func{ RELOCATION_ID(49858, 50790) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(49858, 50790) };
 		return func(this);
 	}
 
 	void PlayerCamera::ForceThirdPerson()
 	{
 		using func_t = decltype(&PlayerCamera::ForceThirdPerson);
-		REL::Relocation<func_t> func{ RELOCATION_ID(49863, 50796) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(49863, 50796) };
 		return func(this);
 	}
 
@@ -50,14 +50,14 @@ namespace RE
 	void PlayerCamera::ToggleFreeCameraMode(bool a_freezeTime)
 	{
 		using func_t = decltype(&PlayerCamera::ToggleFreeCameraMode);
-		REL::Relocation<func_t> func{ RELOCATION_ID(49876, 50809) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(49876, 50809) };
 		return func(this, a_freezeTime);
 	}
 
 	void PlayerCamera::UpdateThirdPerson(bool a_weaponDrawn)
 	{
 		using func_t = decltype(&PlayerCamera::UpdateThirdPerson);
-		REL::Relocation<func_t> func{ Offset::PlayerCamera::UpdateThirdPerson };
+		static REL::Relocation<func_t> func{ Offset::PlayerCamera::UpdateThirdPerson };
 		return func(this, a_weaponDrawn);
 	}
 }

--- a/src/RE/P/PlayerCharacter.cpp
+++ b/src/RE/P/PlayerCharacter.cpp
@@ -7,7 +7,7 @@ namespace RE
 	void PlayerCharacter::PlayerSkills::AdvanceLevel(bool a_addThreshold)
 	{
 		using func_t = decltype(&PlayerCharacter::PlayerSkills::AdvanceLevel);
-		REL::Relocation<func_t> func{ Offset::PlayerCharacter::PlayerSkills::AdvanceLevel };
+		static REL::Relocation<func_t> func{ Offset::PlayerCharacter::PlayerSkills::AdvanceLevel };
 		return func(this, a_addThreshold);
 	}
 
@@ -26,21 +26,21 @@ namespace RE
 	void PlayerCharacter::ActivatePickRef()
 	{
 		using func_t = decltype(&PlayerCharacter::ActivatePickRef);
-		REL::Relocation<func_t> func{ Offset::PlayerCharacter::ActivatePickRef };
+		static REL::Relocation<func_t> func{ Offset::PlayerCharacter::ActivatePickRef };
 		return func(this);
 	}
 
 	void PlayerCharacter::AddPlayerAddItemEvent(TESObject* a_object, TESForm* a_owner, TESObjectREFR* a_container, AQUIRE_TYPE a_type)
 	{
 		using func_t = decltype(&PlayerCharacter::AddPlayerAddItemEvent);
-		REL::Relocation<func_t> func{ RELOCATION_ID(39384, 40456) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(39384, 40456) };
 		return func(this, a_object, a_owner, a_container, a_type);
 	}
 
 	bool PlayerCharacter::AttemptPickpocket(TESObjectREFR* a_containerRef, InventoryEntryData* a_entry, std::int32_t a_number, bool a_fromContainer)
 	{
 		using func_t = decltype(&PlayerCharacter::AttemptPickpocket);
-		REL::Relocation<func_t> func{ RELOCATION_ID(39568, 40654) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(39568, 40654) };
 		return func(this, a_containerRef, a_entry, a_number, a_fromContainer);
 	}
 
@@ -57,14 +57,14 @@ namespace RE
 	bool PlayerCharacter::CheckCast(MagicItem* a_spell, Effect* a_effect, MagicSystem::CannotCastReason& a_reason)
 	{
 		using func_t = decltype(&PlayerCharacter::CheckCast);
-		REL::Relocation<func_t> func{ RELOCATION_ID(39409, 40484) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(39409, 40484) };
 		return func(this, a_spell, a_effect, a_reason);
 	}
 
 	void PlayerCharacter::DestroyMouseSprings()
 	{
 		using func_t = decltype(&PlayerCharacter::DestroyMouseSprings);
-		REL::Relocation<func_t> func{ RELOCATION_ID(39480, 40557) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(39480, 40557) };
 		return func(this);
 	}
 
@@ -83,14 +83,14 @@ namespace RE
 	float PlayerCharacter::GetArmorValue(InventoryEntryData* a_form)
 	{
 		using func_t = decltype(&PlayerCharacter::GetArmorValue);
-		REL::Relocation<func_t> func{ Offset::PlayerCharacter::GetArmorValue };
+		static REL::Relocation<func_t> func{ Offset::PlayerCharacter::GetArmorValue };
 		return func(this, a_form);
 	}
 
 	float PlayerCharacter::GetDamage(InventoryEntryData* a_form)
 	{
 		using func_t = decltype(&PlayerCharacter::GetDamage);
-		REL::Relocation<func_t> func{ Offset::PlayerCharacter::GetDamage };
+		static REL::Relocation<func_t> func{ Offset::PlayerCharacter::GetDamage };
 		return func(this, a_form);
 	}
 
@@ -102,14 +102,14 @@ namespace RE
 	std::int32_t PlayerCharacter::GetItemCount(TESBoundObject* a_object)
 	{
 		using func_t = decltype(&PlayerCharacter::GetItemCount);
-		REL::Relocation<func_t> func{ RELOCATION_ID(19275, 19701) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19275, 19701) };
 		return func(this, a_object);
 	}
 
 	std::uint32_t PlayerCharacter::GetNumTints(std::uint32_t a_tintType)
 	{
 		using func_t = decltype(&PlayerCharacter::GetNumTints);
-		REL::Relocation<func_t> func{ Offset::PlayerCharacter::GetNumTints };
+		static REL::Relocation<func_t> func{ Offset::PlayerCharacter::GetNumTints };
 		return func(this, a_tintType);
 	}
 
@@ -136,7 +136,7 @@ namespace RE
 	TintMask* PlayerCharacter::GetTintMask(std::uint32_t a_tintType, std::uint32_t a_index)
 	{
 		using func_t = decltype(&PlayerCharacter::GetTintMask);
-		REL::Relocation<func_t> func{ Offset::PlayerCharacter::GetTintMask };
+		static REL::Relocation<func_t> func{ Offset::PlayerCharacter::GetTintMask };
 		return func(this, a_tintType, a_index);
 	}
 
@@ -153,56 +153,56 @@ namespace RE
 	void PlayerCharacter::PlayMagicFailureSound(MagicSystem::SpellType a_spellType)
 	{
 		using func_t = decltype(&PlayerCharacter::PlayMagicFailureSound);
-		REL::Relocation<func_t> func{ RELOCATION_ID(39486, 40565) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(39486, 40565) };
 		return func(this, a_spellType);
 	}
 
 	void PlayerCharacter::PlayPickupEvent(TESForm* a_item, TESForm* a_containerOwner, TESObjectREFR* a_containerRef, EventType a_eventType)
 	{
 		using func_t = decltype(&PlayerCharacter::PlayPickupEvent);
-		REL::Relocation<func_t> func{ Offset::PlayerCharacter::PlayPickupEvent };
+		static REL::Relocation<func_t> func{ Offset::PlayerCharacter::PlayPickupEvent };
 		return func(this, a_item, a_containerOwner, a_containerRef, a_eventType);
 	}
 
 	void PlayerCharacter::SetAIDriven(bool a_enable)
 	{
 		using func_t = decltype(&PlayerCharacter::SetAIDriven);
-		REL::Relocation<func_t> func{ RELOCATION_ID(39507, 40586) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(39507, 40586) };
 		return func(this, a_enable);
 	}
 
 	void PlayerCharacter::SetEscaping(bool a_flag, bool a_escaped)
 	{
 		using func_t = decltype(&PlayerCharacter::SetEscaping);
-		REL::Relocation<func_t> func{ RELOCATION_ID(39574, 40660) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(39574, 40660) };
 		return func(this, a_flag, a_escaped);
 	}
 
 	void PlayerCharacter::StartGrabObject()
 	{
 		using func_t = decltype(&PlayerCharacter::StartGrabObject);
-		REL::Relocation<func_t> func{ Offset::PlayerCharacter::StartGrabObject };
+		static REL::Relocation<func_t> func{ Offset::PlayerCharacter::StartGrabObject };
 		return func(this);
 	}
 
 	void PlayerCharacter::UpdateCrosshairs()
 	{
 		using func_t = decltype(&PlayerCharacter::UpdateCrosshairs);
-		REL::Relocation<func_t> func(RELOCATION_ID(39535, 40621));
+		static REL::Relocation<func_t> func(RELOCATION_ID(39535, 40621));
 		return func(this);
 	}
 
 	bool PlayerCharacter::CenterOnCell_Impl(const char* a_cellName, RE::TESObjectCELL* a_cell)
 	{
 		using func_t = decltype(&PlayerCharacter::CenterOnCell_Impl);
-		REL::Relocation<func_t> func{ RELOCATION_ID(39365, 40437) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(39365, 40437) };
 		return func(this, a_cellName, a_cell);
 	}
 
 	void PlayerCharacter::AddSkillExperience(ActorValue a_skill, float a_experience)
 	{
 		using func_t = decltype(&PlayerCharacter::AddSkillExperience);
-		REL::Relocation<func_t> func(RELOCATION_ID(39413, 40488));
+		static REL::Relocation<func_t> func(RELOCATION_ID(39413, 40488));
 		return func(this, a_skill, a_experience);
 	}
 }

--- a/src/RE/P/PlayerControls.cpp
+++ b/src/RE/P/PlayerControls.cpp
@@ -19,7 +19,7 @@ namespace RE
 	PlayerControls* PlayerControls::Ctor()
 	{
 		using func_t = decltype(&PlayerControls::Ctor);
-		REL::Relocation<func_t> func{ Offset::PlayerControls::Ctor };
+		static REL::Relocation<func_t> func{ Offset::PlayerControls::Ctor };
 		return func(this);
 	}
 }

--- a/src/RE/P/ProcessLists.cpp
+++ b/src/RE/P/ProcessLists.cpp
@@ -17,7 +17,7 @@ namespace RE
 	void ProcessLists::ClearCachedFactionFightReactions() const
 	{
 		using func_t = decltype(&ProcessLists::ClearCachedFactionFightReactions);
-		REL::Relocation<func_t> func{ RELOCATION_ID(40396, 41410) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(40396, 41410) };
 		return func(this);
 	}
 
@@ -82,14 +82,14 @@ namespace RE
 	float ProcessLists::GetSystemTimeClock()
 	{
 		using func_t = decltype(&ProcessLists::GetSystemTimeClock);
-		REL::Relocation<func_t> func{ RELOCATION_ID(40327, 41337) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(40327, 41337) };
 		return func(this);
 	}
 
 	std::int16_t ProcessLists::RequestHighestDetectionLevelAgainstActor(Actor* a_actor, std::uint32_t& a_LOSCount)
 	{
 		using func_t = decltype(&ProcessLists::RequestHighestDetectionLevelAgainstActor);
-		REL::Relocation<func_t> func{ RELOCATION_ID(40394, 41408) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(40394, 41408) };
 		return func(this, a_actor, a_LOSCount);
 	}
 
@@ -108,7 +108,7 @@ namespace RE
 	void ProcessLists::StopCombatAndAlarmOnActor(Actor* a_actor, bool a_notAlarm)
 	{
 		using func_t = decltype(&ProcessLists::StopCombatAndAlarmOnActor);
-		REL::Relocation<func_t> func{ RELOCATION_ID(40330, 41340) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(40330, 41340) };
 		return func(this, a_actor, a_notAlarm);
 	}
 }

--- a/src/RE/P/Projectile.cpp
+++ b/src/RE/P/Projectile.cpp
@@ -91,7 +91,7 @@ namespace RE
 	ProjectileHandle* Projectile::Launch(ProjectileHandle* a_result, LaunchData& a_data) noexcept
 	{
 		using func_t = decltype(&Projectile::Launch);
-		REL::Relocation<func_t> func{ RELOCATION_ID(42928, 44108) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(42928, 44108) };
 		return func(a_result, a_data);
 	}
 

--- a/src/RE/Q/QuestStatus.cpp
+++ b/src/RE/Q/QuestStatus.cpp
@@ -5,7 +5,7 @@ namespace RE
 	BSTEventSource<QuestStatus::Event>* QuestStatus::GetEventSource()
 	{
 		using func_t = decltype(&QuestStatus::GetEventSource);
-		REL::Relocation<func_t> func{ RELOCATION_ID(24719, 25196) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(24719, 25196) };
 		return func();
 	}
 }

--- a/src/RE/R/RaceSexMenu.cpp
+++ b/src/RE/R/RaceSexMenu.cpp
@@ -5,7 +5,7 @@ namespace RE
 	void RaceSexMenu::ChangeName(const char* a_name)
 	{
 		using func_t = decltype(&RaceSexMenu::ChangeName);
-		REL::Relocation<func_t> func{ Offset::RaceSexMenu::ChangeName };
+		static REL::Relocation<func_t> func{ Offset::RaceSexMenu::ChangeName };
 		return func(this, a_name);
 	}
 }

--- a/src/RE/R/Renderer.cpp
+++ b/src/RE/R/Renderer.cpp
@@ -15,119 +15,119 @@ namespace RE
 		NiTexture::RendererData* Renderer::CreateRenderTexture(std::uint32_t a_width, std::uint32_t a_height)
 		{
 			using func_t = decltype(&Renderer::CreateRenderTexture);
-			REL::Relocation<func_t> func{ RELOCATION_ID(75507, 77299) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(75507, 77299) };
 			return func(this, a_width, a_height);
 		}
 
 		void Renderer::SaveRenderTargetToFile(RENDER_TARGET a_renderTarget, const char* a_filePath, BSGraphics::TextureFileFormat a_textureFileFormat)
 		{
 			using func_t = decltype(&Renderer::SaveRenderTargetToFile);
-			REL::Relocation<func_t> func{ RELOCATION_ID(75522, 77316) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(75522, 77316) };
 			return func(this, a_renderTarget, a_filePath, a_textureFileFormat);
 		}
 
 		void Renderer::Init(RendererInitOSData* a_data, ApplicationWindowProperties* a_windowProps, REX::W32::HWND a_window)
 		{
 			using func_t = decltype(&Renderer::Init);
-			REL::Relocation<func_t> func{ RELOCATION_ID(75445, 77226) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(75445, 77226) };
 			return func(this, a_data, a_windowProps, a_window);
 		}
 
 		void Renderer::Begin(std::uint32_t a_windowID)
 		{
 			using func_t = decltype(&Renderer::Begin);
-			REL::Relocation<func_t> func{ RELOCATION_ID(75460, 77245) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(75460, 77245) };
 			return func(this, a_windowID);
 		}
 
 		void Renderer::CreateSwapChain(REX::W32::HWND* a_window, bool a_setCurrent)
 		{
 			using func_t = decltype(&Renderer::CreateSwapChain);
-			REL::Relocation<func_t> func{ RELOCATION_ID(75457, 77242) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(75457, 77242) };
 			return func(this, a_window, a_setCurrent);
 		}
 
 		void Renderer::End()
 		{
 			using func_t = decltype(&Renderer::End);
-			REL::Relocation<func_t> func{ RELOCATION_ID(75461, 77246) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(75461, 77246) };
 			return func(this);
 		}
 
 		void Renderer::KillWindow(std::uint32_t a_windowID)
 		{
 			using func_t = decltype(&Renderer::KillWindow);
-			REL::Relocation<func_t> func{ RELOCATION_ID(75452, 77237) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(75452, 77237) };
 			return func(this, a_windowID);
 		}
 
 		void Renderer::Lock()
 		{
 			using func_t = decltype(&Renderer::Lock);
-			REL::Relocation<func_t> func{ RELOCATION_ID(75458, 77243) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(75458, 77243) };
 			return func(this);
 		}
 
 		void Renderer::Unlock()
 		{
 			using func_t = decltype(&Renderer::Unlock);
-			REL::Relocation<func_t> func{ RELOCATION_ID(75459, 77244) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(75459, 77244) };
 			return func(this);
 		}
 
 		void Renderer::ResizeWindow(std::uint32_t a_windowID, std::uint32_t a_width, std::uint32_t a_height, bool a_fullscreen, bool a_borderless)
 		{
 			using func_t = decltype(&Renderer::ResizeWindow);
-			REL::Relocation<func_t> func{ RELOCATION_ID(75454, 77239) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(75454, 77239) };
 			return func(this, a_windowID, a_width, a_height, a_fullscreen, a_borderless);
 		}
 
 		void Renderer::RequestWindowResize(std::uint32_t a_width, std::uint32_t a_height)
 		{
 			using func_t = decltype(&Renderer::RequestWindowResize);
-			REL::Relocation<func_t> func{ RELOCATION_ID(75450, 77235) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(75450, 77235) };
 			return func(this, a_width, a_height);
 		}
 
 		void Renderer::SetWindowPosition(std::uint32_t a_windowID, std::int32_t a_x, std::int32_t a_y)
 		{
 			using func_t = decltype(&Renderer::SetWindowPosition);
-			REL::Relocation<func_t> func{ RELOCATION_ID(75448, 77233) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(75448, 77233) };
 			return func(this, a_windowID, a_x, a_y);
 		}
 
 		void Renderer::SetWindowActiveState(bool a_show)
 		{
 			using func_t = decltype(&Renderer::SetWindowActiveState);
-			REL::Relocation<func_t> func{ RELOCATION_ID(75451, 77236) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(75451, 77236) };
 			return func(this, a_show);
 		}
 
 		void Renderer::WindowSizeChanged(std::uint32_t a_windowID)
 		{
 			using func_t = decltype(&Renderer::WindowSizeChanged);
-			REL::Relocation<func_t> func{ RELOCATION_ID(75453, 77238) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(75453, 77238) };
 			return func(this, a_windowID);
 		}
 
 		void Renderer::ResetWindow(std::uint32_t a_windowID)
 		{
 			using func_t = decltype(&Renderer::ResetWindow);
-			REL::Relocation<func_t> func{ RELOCATION_ID(75454, 77239) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(75454, 77239) };
 			return func(this, a_windowID);
 		}
 
 		void Renderer::UpdateViewPort(std::uint32_t a_unk1, std::uint32_t a_unk2, bool a_unk3)
 		{
 			using func_t = decltype(&Renderer::UpdateViewPort);
-			REL::Relocation<func_t> func{ RELOCATION_ID(75455, 77240) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(75455, 77240) };
 			return func(this, a_unk1, a_unk2, a_unk3);
 		}
 
 		void Renderer::Shutdown()
 		{
 			using func_t = decltype(&Renderer::Shutdown);
-			REL::Relocation<func_t> func{ RELOCATION_ID(75447, 77228) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(75447, 77228) };
 			return func(this);
 		}
 

--- a/src/RE/R/Rumble.cpp
+++ b/src/RE/R/Rumble.cpp
@@ -8,7 +8,7 @@ namespace RE
 		//  pVibration = 0;
 		//  return XInputSetState(0, &pVibration);
 		using func_t = decltype(&Rumble::DisableRumble);
-		REL::Relocation<func_t> func{ RELOCATION_ID(67224, 68533) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(67224, 68533) };
 		return func();
 	}
 }

--- a/src/RE/S/ScrapHeap.cpp
+++ b/src/RE/S/ScrapHeap.cpp
@@ -5,14 +5,14 @@ namespace RE
 	void* ScrapHeap::Allocate(std::size_t a_size, std::size_t a_alignment)
 	{
 		using func_t = decltype(&ScrapHeap::Allocate);
-		REL::Relocation<func_t> func{ RELOCATION_ID(66884, 68144) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(66884, 68144) };
 		return func(this, a_size, a_alignment);
 	}
 
 	void ScrapHeap::Deallocate(void* a_mem)
 	{
 		using func_t = decltype(&ScrapHeap::Deallocate);
-		REL::Relocation<func_t> func{ RELOCATION_ID(66885, 68146) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(66885, 68146) };
 		return func(this, a_mem);
 	}
 }

--- a/src/RE/S/Script.cpp
+++ b/src/RE/S/Script.cpp
@@ -7,14 +7,14 @@ namespace RE
 	bool Script::GetProcessScripts()
 	{
 		using func_t = decltype(&Script::GetProcessScripts);
-		REL::Relocation<func_t> func{ Offset::Script::GetProcessScripts };
+		static REL::Relocation<func_t> func{ Offset::Script::GetProcessScripts };
 		return func();
 	}
 
 	void Script::SetProcessScripts(bool a_ProcessScripts)
 	{
 		using func_t = decltype(&Script::SetProcessScripts);
-		REL::Relocation<func_t> func{ Offset::Script::SetProcessScripts };
+		static REL::Relocation<func_t> func{ Offset::Script::SetProcessScripts };
 		return func(a_ProcessScripts);
 	}
 
@@ -56,7 +56,7 @@ namespace RE
 	void Script::CompileAndRun_Impl(ScriptCompiler* a_compiler, COMPILER_NAME a_name, TESObjectREFR* a_targetRef)
 	{
 		using func_t = decltype(&Script::CompileAndRun_Impl);
-		REL::Relocation<func_t> func{ Offset::Script::CompileAndRun };
+		static REL::Relocation<func_t> func{ Offset::Script::CompileAndRun };
 		return func(this, a_compiler, a_name, a_targetRef);
 	}
 }

--- a/src/RE/S/ScriptEventSourceHolder.cpp
+++ b/src/RE/S/ScriptEventSourceHolder.cpp
@@ -9,7 +9,7 @@ namespace RE
 	ScriptEventSourceHolder* ScriptEventSourceHolder::GetSingleton()
 	{
 		using func_t = decltype(&ScriptEventSourceHolder::GetSingleton);
-		REL::Relocation<func_t> func{ RELOCATION_ID(14108, 14298) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(14108, 14298) };
 		return func();
 	}
 
@@ -26,7 +26,7 @@ namespace RE
 	void ScriptEventSourceHolder::SendOpenCloseEvent(const NiPointer<TESObjectREFR>& a_ref, const NiPointer<TESObjectREFR>& a_activeRef, bool a_isOpened)
 	{
 		using func_t = decltype(&ScriptEventSourceHolder::SendOpenCloseEvent);
-		REL::Relocation<func_t> func{ RELOCATION_ID(14190, 14299) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(14190, 14299) };
 		return func(this, a_ref, a_activeRef, a_isOpened);
 	}
 

--- a/src/RE/S/ShoutAttack.cpp
+++ b/src/RE/S/ShoutAttack.cpp
@@ -5,7 +5,7 @@ namespace RE
 	BSTEventSource<ShoutAttack::Event>* ShoutAttack::GetEventSource()
 	{
 		using func_t = decltype(&ShoutAttack::GetEventSource);
-		REL::Relocation<func_t> func{ RELOCATION_ID(40060, 41071) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(40060, 41071) };
 		return func();
 	}
 }

--- a/src/RE/S/SkillIncrease.cpp
+++ b/src/RE/S/SkillIncrease.cpp
@@ -5,7 +5,7 @@ namespace RE
 	BSTEventSource<SkillIncrease::Event>* SkillIncrease::GetEventSource()
 	{
 		using func_t = decltype(&SkillIncrease::GetEventSource);
-		REL::Relocation<func_t> func{ RELOCATION_ID(39248, 40320) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(39248, 40320) };
 		return func();
 	}
 }

--- a/src/RE/S/Sky.cpp
+++ b/src/RE/S/Sky.cpp
@@ -8,7 +8,7 @@ namespace RE
 	Sky* Sky::GetSingleton()
 	{
 		using func_t = decltype(&Sky::GetSingleton);
-		REL::Relocation<func_t> func{ RELOCATION_ID(13789, 13878) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(13789, 13878) };
 		return func();
 	}
 
@@ -71,7 +71,7 @@ namespace RE
 	void Sky::ForceWeather(TESWeather* a_weather, bool a_override)
 	{
 		using func_t = decltype(&Sky::ForceWeather);
-		REL::Relocation<func_t> func{ RELOCATION_ID(25696, 26243) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(25696, 26243) };
 		func(this, a_weather, a_override);
 	}
 
@@ -98,14 +98,14 @@ namespace RE
 	void Sky::ResetWeather()
 	{
 		using func_t = decltype(&Sky::ResetWeather);
-		REL::Relocation<func_t> func{ RELOCATION_ID(25695, 26242) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(25695, 26242) };
 		func(this);
 	}
 
 	void Sky::SetWeather(TESWeather* a_weather, bool a_override, bool a_accelerate)
 	{
 		using func_t = decltype(&Sky::SetWeather);
-		REL::Relocation<func_t> func{ RELOCATION_ID(25694, 26241) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(25694, 26241) };
 		func(this, a_weather, a_override, a_accelerate);
 	}
 }

--- a/src/RE/S/SkyrimVM.cpp
+++ b/src/RE/S/SkyrimVM.cpp
@@ -12,14 +12,14 @@ namespace RE
 	bool SkyrimVM::QueuePostRenderCall(const BSTSmartPointer<SkyrimScript::DelayFunctor>& a_functor)
 	{
 		using func_t = decltype(&SkyrimVM::QueuePostRenderCall);
-		REL::Relocation<func_t> func{ Offset::SkyrimVM::QueuePostRenderCall };
+		static REL::Relocation<func_t> func{ Offset::SkyrimVM::QueuePostRenderCall };
 		return func(this, a_functor);
 	}
 
 	void SkyrimVM::RelayEvent(VMHandle a_handle, BSFixedString* a_event, BSScript::IFunctionArguments* a_args, SkyrimVM::ISendEventFilter* a_optionalFilter)
 	{
 		using func_t = decltype(&SkyrimVM::RelayEvent);
-		REL::Relocation<func_t> func{ Offset::SkyrimVM::RelayEvent };
+		static REL::Relocation<func_t> func{ Offset::SkyrimVM::RelayEvent };
 		return func(this, a_handle, a_event, a_args, a_optionalFilter);
 	}
 

--- a/src/RE/S/SoulsTrapped.cpp
+++ b/src/RE/S/SoulsTrapped.cpp
@@ -5,7 +5,7 @@ namespace RE
 	BSTEventSource<SoulsTrapped::Event>* SoulsTrapped::GetEventSource()
 	{
 		using func_t = decltype(&SoulsTrapped::GetEventSource);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37916, 38873) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37916, 38873) };
 		return func();
 	}
 

--- a/src/RE/S/SourceActionMap.cpp
+++ b/src/RE/S/SourceActionMap.cpp
@@ -27,7 +27,7 @@ namespace RE
 		bool DoAction(Actor* a_actor, DEFAULT_OBJECT a_action)
 		{
 			using func_t = decltype(&SourceActionMap::DoAction);
-			REL::Relocation<func_t> func{ RELOCATION_ID(33423, 34202) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(33423, 34202) };
 			return func(a_actor, a_action);
 		}
 	}

--- a/src/RE/S/SpellsLearned.cpp
+++ b/src/RE/S/SpellsLearned.cpp
@@ -5,7 +5,7 @@ namespace RE
 	BSTEventSource<SpellsLearned::Event>* SpellsLearned::GetEventSource()
 	{
 		using func_t = decltype(&SpellsLearned::GetEventSource);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37917, 38874) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37917, 38874) };
 		return func();
 	}
 

--- a/src/RE/S/Stack.cpp
+++ b/src/RE/S/Stack.cpp
@@ -28,14 +28,14 @@ namespace RE
 		Variable& Stack::GetStackFrameVariable(const StackFrame* a_frame, std::uint32_t a_index, std::uint32_t a_pageHint)
 		{
 			using func_t = decltype(&Stack::GetStackFrameVariable);
-			REL::Relocation<func_t> func{ RELOCATION_ID(97746, 104484) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(97746, 104484) };
 			return func(this, a_frame, a_index, a_pageHint);
 		}
 
 		void Stack::Dtor()
 		{
 			using func_t = decltype(&Stack::Dtor);
-			REL::Relocation<func_t> func{ RELOCATION_ID(97742, 104480) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(97742, 104480) };
 			return func(this);
 		}
 	}

--- a/src/RE/T/TES.cpp
+++ b/src/RE/T/TES.cpp
@@ -97,49 +97,49 @@ namespace RE
 	TESObjectCELL* TES::GetCell(const NiPoint3& a_position) const
 	{
 		using func_t = decltype(&TES::GetCell);
-		REL::Relocation<func_t> func{ RELOCATION_ID(13177, 13322) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(13177, 13322) };
 		return func(this, a_position);
 	}
 
 	MATERIAL_ID TES::GetLandMaterialType(const NiPoint3& a_position) const
 	{
 		using func_t = decltype(&TES::GetLandMaterialType);
-		REL::Relocation<func_t> func{ RELOCATION_ID(13203, 13349) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(13203, 13349) };
 		return func(this, a_position);
 	}
 
 	bool TES::GetLandHeight(const NiPoint3& a_positionIn, float& a_heightOut)
 	{
 		using func_t = decltype(&TES::GetLandHeight);
-		REL::Relocation<func_t> func{ RELOCATION_ID(13198, 13344) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(13198, 13344) };
 		return func(this, a_positionIn, a_heightOut);
 	}
 
 	TESLandTexture* TES::GetLandTexture(const NiPoint3& a_position) const
 	{
 		using func_t = decltype(&TES::GetLandTexture);
-		REL::Relocation<func_t> func{ RELOCATION_ID(13202, 13348) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(13202, 13348) };
 		return func(this, a_position);
 	}
 
 	float TES::GetWaterHeight(const NiPoint3& a_pos, TESObjectCELL* a_cell) const
 	{
 		using func_t = decltype(&TES::GetWaterHeight);
-		REL::Relocation<func_t> func{ RELOCATION_ID(13212, 13358) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(13212, 13358) };
 		return func(this, a_pos, a_cell);
 	}
 
 	NiAVObject* TES::Pick(bhkPickData& a_pickData)
 	{
 		using func_t = decltype(&TES::Pick);
-		REL::Relocation<func_t> func{ RELOCATION_ID(13221, 13371) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(13221, 13371) };
 		return func(this, a_pickData);
 	}
 
 	void TES::PurgeBufferedCells()
 	{
 		using func_t = decltype(&TES::PurgeBufferedCells);
-		REL::Relocation<func_t> func{ RELOCATION_ID(13159, 13299) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(13159, 13299) };
 		return func(this);
 	}
 }

--- a/src/RE/T/TESCamera.cpp
+++ b/src/RE/T/TESCamera.cpp
@@ -5,7 +5,7 @@ namespace RE
 	void TESCamera::SetState(TESCameraState* a_state)
 	{
 		using func_t = decltype(&TESCamera::SetState);
-		REL::Relocation<func_t> func{ Offset::TESCamera::SetState };
+		static REL::Relocation<func_t> func{ Offset::TESCamera::SetState };
 		return func(this, a_state);
 	}
 }

--- a/src/RE/T/TESCondition.cpp
+++ b/src/RE/T/TESCondition.cpp
@@ -46,7 +46,7 @@ namespace RE
 	bool TESConditionItem::IsTrue(ConditionCheckParams& a_solution) const
 	{
 		using func_t = decltype(&TESConditionItem::IsTrue);
-		REL::Relocation<func_t> func{ RELOCATION_ID(29090, 29924) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(29090, 29924) };
 		return func(this, a_solution);
 	}
 
@@ -78,7 +78,7 @@ namespace RE
 	bool TESCondition::IsTrue(TESObjectREFR* a_actionRef, TESObjectREFR* a_targetRef) const
 	{
 		using func_t = decltype(&TESCondition::IsTrue);
-		REL::Relocation<func_t> func{ RELOCATION_ID(29074, 29888) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(29074, 29888) };
 		return func(this, a_actionRef, a_targetRef);
 	}
 }

--- a/src/RE/T/TESDataHandler.cpp
+++ b/src/RE/T/TESDataHandler.cpp
@@ -14,14 +14,14 @@ namespace RE
 	bool TESDataHandler::AddFormToDataHandler(TESForm* a_form)
 	{
 		using func_t = decltype(&TESDataHandler::AddFormToDataHandler);
-		REL::Relocation<func_t> func{ RELOCATION_ID(13597, 13693) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(13597, 13693) };
 		return func(this, a_form);
 	}
 
 	std::uint32_t TESDataHandler::LoadScripts()
 	{
 		using func_t = decltype(&TESDataHandler::LoadScripts);
-		REL::Relocation<func_t> func{ Offset::TESDataHandler::LoadScripts };
+		static REL::Relocation<func_t> func{ Offset::TESDataHandler::LoadScripts };
 		return func(this);
 	}
 
@@ -137,7 +137,7 @@ namespace RE
 	ObjectRefHandle TESDataHandler::CreateReferenceAtLocation(TESBoundObject* a_base, const NiPoint3& a_location, const NiPoint3& a_rotation, TESObjectCELL* a_targetCell, TESWorldSpace* a_selfWorldSpace, TESObjectREFR* a_alreadyCreatedRef, BGSPrimitive* a_primitive, const ObjectRefHandle& a_linkedRoomRefHandle, bool a_forcePersist, bool a_arg11)
 	{
 		using func_t = decltype(&TESDataHandler::CreateReferenceAtLocation);
-		REL::Relocation<func_t> func{ RELOCATION_ID(13625, 13723) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(13625, 13723) };
 		return func(this, a_base, a_location, a_rotation, a_targetCell, a_selfWorldSpace, a_alreadyCreatedRef, a_primitive, a_linkedRoomRefHandle, a_forcePersist, a_arg11);
 	}
 }

--- a/src/RE/T/TESDescription.cpp
+++ b/src/RE/T/TESDescription.cpp
@@ -7,7 +7,7 @@ namespace RE
 	void TESDescription::GetDescription(BSString& a_out, TESForm* a_parent, std::uint32_t a_fieldType)
 	{
 		using func_t = decltype(&TESDescription::GetDescription);
-		REL::Relocation<func_t> func{ Offset::TESDescription::GetDescription };
+		static REL::Relocation<func_t> func{ Offset::TESDescription::GetDescription };
 		return func(this, a_out, a_parent, a_fieldType);
 	}
 }

--- a/src/RE/T/TESFaction.cpp
+++ b/src/RE/T/TESFaction.cpp
@@ -264,7 +264,7 @@ namespace RE
 	void TESFaction::SetFactionFightReaction(TESFaction* a_faction, FIGHT_REACTION a_fightReaction)
 	{
 		using func_t = decltype(&TESFaction::SetFactionFightReaction);
-		REL::Relocation<func_t> func{ RELOCATION_ID(24012, 24516) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(24012, 24516) };
 		return func(this, a_faction, a_fightReaction);
 	}
 

--- a/src/RE/T/TESFile.cpp
+++ b/src/RE/T/TESFile.cpp
@@ -5,28 +5,28 @@ namespace RE
 	bool TESFile::CloseTES(bool a_force)
 	{
 		using func_t = decltype(&TESFile::CloseTES);
-		REL::Relocation<func_t> func{ RELOCATION_ID(13857, 13933) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(13857, 13933) };
 		return func(this, a_force);
 	}
 
 	TESFile* TESFile::Duplicate(std::uint32_t a_cacheSize)
 	{
 		using func_t = decltype(&TESFile::Duplicate);
-		REL::Relocation<func_t> func{ Offset::TESFile::Duplicate };
+		static REL::Relocation<func_t> func{ Offset::TESFile::Duplicate };
 		return func(this, a_cacheSize);
 	}
 
 	std::uint32_t TESFile::GetCurrentSubRecordType()
 	{
 		using func_t = decltype(&TESFile::GetCurrentSubRecordType);
-		REL::Relocation<func_t> func{ Offset::TESFile::GetCurrentSubRecordType };
+		static REL::Relocation<func_t> func{ Offset::TESFile::GetCurrentSubRecordType };
 		return func(this);
 	}
 
 	FormType TESFile::GetFormType()
 	{
 		using func_t = decltype(&TESFile::GetFormType);
-		REL::Relocation<func_t> func{ Offset::TESFile::GetFormType };
+		static REL::Relocation<func_t> func{ Offset::TESFile::GetFormType };
 		return func(this);
 	}
 
@@ -44,35 +44,35 @@ namespace RE
 	bool TESFile::OpenTES(NiFile::OpenMode a_accessMode, bool a_lock)
 	{
 		using func_t = decltype(&TESFile::OpenTES);
-		REL::Relocation<func_t> func{ RELOCATION_ID(13855, 13931) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(13855, 13931) };
 		return func(this, a_accessMode, a_lock);
 	}
 
 	bool TESFile::ReadData(void* a_buf, std::uint32_t a_size)
 	{
 		using func_t = decltype(&TESFile::ReadData);
-		REL::Relocation<func_t> func{ Offset::TESFile::ReadData };
+		static REL::Relocation<func_t> func{ Offset::TESFile::ReadData };
 		return func(this, a_buf, a_size);
 	}
 
 	bool TESFile::Seek(std::uint32_t a_offset)
 	{
 		using func_t = decltype(&TESFile::Seek);
-		REL::Relocation<func_t> func{ Offset::TESFile::Seek };
+		static REL::Relocation<func_t> func{ Offset::TESFile::Seek };
 		return func(this, a_offset);
 	}
 
 	bool TESFile::SeekNextForm(bool a_skipIgnored)
 	{
 		using func_t = decltype(&TESFile::SeekNextForm);
-		REL::Relocation<func_t> func{ RELOCATION_ID(13894, 13979) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(13894, 13979) };
 		return func(this, a_skipIgnored);
 	}
 
 	bool TESFile::SeekNextSubrecord()
 	{
 		using func_t = decltype(&TESFile::SeekNextSubrecord);
-		REL::Relocation<func_t> func{ Offset::TESFile::SeekNextSubrecord };
+		static REL::Relocation<func_t> func{ Offset::TESFile::SeekNextSubrecord };
 		return func(this);
 	}
 }

--- a/src/RE/T/TESForm.cpp
+++ b/src/RE/T/TESForm.cpp
@@ -182,7 +182,7 @@ namespace RE
 	void TESForm::SetPlayerKnows(bool a_known)
 	{
 		using func_t = decltype(&TESForm::SetPlayerKnows);
-		REL::Relocation<func_t> func{ RELOCATION_ID(14482, 14639) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(14482, 14639) };
 		return func(this, a_known);
 	}
 }

--- a/src/RE/T/TESHavokUtilities.cpp
+++ b/src/RE/T/TESHavokUtilities.cpp
@@ -7,49 +7,49 @@ namespace RE
 		void AddExplosionImpulse(NiAVObject* a_obj3D, hkVector4& a_pos, float a_force, const HitData* a_hitData)
 		{
 			using func_t = decltype(&AddExplosionImpulse);
-			REL::Relocation<func_t> func{ RELOCATION_ID(25468, 26005) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(25468, 26005) };
 			return func(a_obj3D, a_pos, a_force, a_hitData);
 		}
 
 		TESObjectREFR* FindCollidableRef(const hkpCollidable& a_linkedCollidable)
 		{
 			using func_t = decltype(&FindCollidableRef);
-			REL::Relocation<func_t> func{ Offset::TESHavokUtilities::FindCollidableRef };
+			static REL::Relocation<func_t> func{ Offset::TESHavokUtilities::FindCollidableRef };
 			return func(a_linkedCollidable);
 		}
 
 		NiAVObject* FindCollidableObject(const hkpCollidable& a_linkedCollidable)
 		{
 			using func_t = decltype(&FindCollidableObject);
-			REL::Relocation<func_t> func{ RELOCATION_ID(15644, 15870) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(15644, 15870) };
 			return func(a_linkedCollidable);
 		}
 
 		float GetDamageForImpact(float a_mass, float a_speed)
 		{
 			using func_t = decltype(&GetDamageForImpact);
-			REL::Relocation<func_t> func{ RELOCATION_ID(25478, 26018) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(25478, 26018) };
 			return func(a_mass, a_speed);
 		}
 
 		void PopTemporaryMass(bhkRigidBody* a_body)
 		{
 			using func_t = decltype(&PopTemporaryMass);
-			REL::Relocation<func_t> func{ RELOCATION_ID(25484, 26024) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(25484, 26024) };
 			return func(a_body);
 		}
 
 		void PushTemporaryMass(bhkRigidBody* a_body, float a_mass)
 		{
 			using func_t = decltype(&PushTemporaryMass);
-			REL::Relocation<func_t> func{ RELOCATION_ID(25483, 26023) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(25483, 26023) };
 			return func(a_body, a_mass);
 		}
 
 		float ScaleGameplayImpulseForce(float a_inputForce, bhkRigidBody* a_body, bool a_factorMass)
 		{
 			using func_t = decltype(&ScaleGameplayImpulseForce);
-			REL::Relocation<func_t> func{ RELOCATION_ID(25467, 26004) };
+			static REL::Relocation<func_t> func{ RELOCATION_ID(25467, 26004) };
 			return func(a_inputForce, a_body, a_factorMass);
 		}
 	}

--- a/src/RE/T/TESLeveledList.cpp
+++ b/src/RE/T/TESLeveledList.cpp
@@ -7,7 +7,7 @@ namespace RE
 	void TESLeveledList::CalculateCurrentFormList(std::uint16_t a_level, std::int16_t a_count, BSScrapArray<CALCED_OBJECT>& a_calcedObjects, std::uint32_t a_arg5, bool a_usePlayerLevel)
 	{
 		using func_t = decltype(&TESLeveledList::CalculateCurrentFormList);
-		REL::Relocation<func_t> func{ RELOCATION_ID(14579, 14751) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(14579, 14751) };
 		return func(this, a_level, a_count, a_calcedObjects, a_arg5, a_usePlayerLevel);
 	}
 

--- a/src/RE/T/TESNPC.cpp
+++ b/src/RE/T/TESNPC.cpp
@@ -52,7 +52,7 @@ namespace RE
 	void TESNPC::ChangeHeadPart(BGSHeadPart* a_target)
 	{
 		using func_t = decltype(&TESNPC::ChangeHeadPart);
-		REL::Relocation<func_t> func{ Offset::TESNPC::ChangeHeadPart };
+		static REL::Relocation<func_t> func{ Offset::TESNPC::ChangeHeadPart };
 		return func(this, a_target);
 	}
 
@@ -70,7 +70,7 @@ namespace RE
 	BGSHeadPart** TESNPC::GetBaseOverlays() const
 	{
 		using func_t = decltype(&TESNPC::GetBaseOverlays);
-		REL::Relocation<func_t> func{ Offset::TESNPC::GetBaseOverlays };
+		static REL::Relocation<func_t> func{ Offset::TESNPC::GetBaseOverlays };
 		return func(this);
 	}
 
@@ -141,7 +141,7 @@ namespace RE
 	std::uint32_t TESNPC::GetNumBaseOverlays() const
 	{
 		using func_t = decltype(&TESNPC::GetNumBaseOverlays);
-		REL::Relocation<func_t> func{ Offset::TESNPC::GetNumBaseOverlays };
+		static REL::Relocation<func_t> func{ Offset::TESNPC::GetNumBaseOverlays };
 		return func(this);
 	}
 
@@ -195,7 +195,7 @@ namespace RE
 	bool TESNPC::HasOverlays()
 	{
 		using func_t = decltype(&TESNPC::HasOverlays);
-		REL::Relocation<func_t> func{ Offset::TESNPC::HasOverlays };
+		static REL::Relocation<func_t> func{ Offset::TESNPC::HasOverlays };
 		return func(this);
 	}
 
@@ -258,7 +258,7 @@ namespace RE
 	void TESNPC::SetSkinFromTint(NiColorA* a_result, TintMask* a_tintMask, bool a_fromTint)
 	{
 		using func_t = decltype(&TESNPC::SetSkinFromTint);
-		REL::Relocation<func_t> func{ Offset::TESNPC::SetSkinFromTint };
+		static REL::Relocation<func_t> func{ Offset::TESNPC::SetSkinFromTint };
 		return func(this, a_result, a_tintMask, a_fromTint);
 	}
 
@@ -271,7 +271,7 @@ namespace RE
 	void TESNPC::UpdateNeck(BSFaceGenNiNode* a_faceNode)
 	{
 		using func_t = decltype(&TESNPC::UpdateNeck);
-		REL::Relocation<func_t> func{ Offset::TESNPC::UpdateNeck };
+		static REL::Relocation<func_t> func{ Offset::TESNPC::UpdateNeck };
 		return func(this, a_faceNode);
 	}
 }

--- a/src/RE/T/TESObjectBOOK.cpp
+++ b/src/RE/T/TESObjectBOOK.cpp
@@ -57,7 +57,7 @@ namespace RE
 	bool TESObjectBOOK::Read(TESObjectREFR* a_reader)
 	{
 		using func_t = decltype(&TESObjectBOOK::Read);
-		REL::Relocation<func_t> func{ RELOCATION_ID(17439, 17842) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(17439, 17842) };
 		return func(this, a_reader);
 	}
 }

--- a/src/RE/T/TESObjectCELL.cpp
+++ b/src/RE/T/TESObjectCELL.cpp
@@ -40,7 +40,7 @@ namespace RE
 	bhkWorld* TESObjectCELL::GetbhkWorld() const
 	{
 		using func_t = decltype(&TESObjectCELL::GetbhkWorld);
-		REL::Relocation<func_t> func{ RELOCATION_ID(18536, 18995) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(18536, 18995) };
 		return func(this);
 	}
 
@@ -63,7 +63,7 @@ namespace RE
 	BGSLocation* TESObjectCELL::GetLocation() const
 	{
 		using func_t = decltype(&TESObjectCELL::GetLocation);
-		REL::Relocation<func_t> func{ RELOCATION_ID(18474, 18905) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(18474, 18905) };
 		return func(this);
 	}
 
@@ -113,14 +113,14 @@ namespace RE
 	TESRegionList* TESObjectCELL::GetRegionList(bool a_createIfMissing)
 	{
 		using func_t = decltype(&TESObjectCELL::GetRegionList);
-		REL::Relocation<func_t> func{ RELOCATION_ID(18540, 18999) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(18540, 18999) };
 		return func(this, a_createIfMissing);
 	}
 
 	bool TESObjectCELL::GetWaterHeight(const NiPoint3& a_pos, float& a_waterHeight)
 	{
 		using func_t = decltype(&TESObjectCELL::GetWaterHeight);
-		REL::Relocation<func_t> func{ RELOCATION_ID(18543, 19002) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(18543, 19002) };
 		return func(this, a_pos, a_waterHeight);
 	}
 

--- a/src/RE/T/TESObjectREFR.cpp
+++ b/src/RE/T/TESObjectREFR.cpp
@@ -33,7 +33,7 @@ namespace RE
 	ObjectRefHandle TESObjectREFR::CreateReference(ObjectRefHandle& a_handleOut, FormType a_formType, bool a_addActorToProcessList)
 	{
 		using func_t = decltype(&TESObjectREFR::CreateReference);
-		REL::Relocation<func_t> func{ RELOCATION_ID(19142, 19544) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19142, 19544) };
 		return func(a_handleOut, a_formType, a_addActorToProcessList);
 	}
 
@@ -52,35 +52,35 @@ namespace RE
 	TESObjectREFR* TESObjectREFR::FindReferenceFor3D(NiAVObject* a_object3D)
 	{
 		using func_t = decltype(&TESObjectREFR::FindReferenceFor3D);
-		REL::Relocation<func_t> func{ Offset::TESObjectREFR::FindReferenceFor3D };
+		static REL::Relocation<func_t> func{ Offset::TESObjectREFR::FindReferenceFor3D };
 		return func(a_object3D);
 	}
 
 	bool TESObjectREFR::ActivateRef(TESObjectREFR* a_activator, uint8_t a_arg2, TESBoundObject* a_object, int32_t a_count, bool a_defaultProcessingOnly)
 	{
 		using func_t = decltype(&TESObjectREFR::ActivateRef);
-		REL::Relocation<func_t> func{ RELOCATION_ID(19369, 19796) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19369, 19796) };
 		return func(this, a_activator, a_arg2, a_object, a_count, a_defaultProcessingOnly);
 	}
 
 	ModelReferenceEffect* TESObjectREFR::ApplyArtObject(BGSArtObject* a_artObject, float a_duration, TESObjectREFR* a_facingRef, bool a_faceTarget, bool a_attachToCamera, NiAVObject* a_attachNode, bool a_interfaceEffect)
 	{
 		using func_t = decltype(&TESObjectREFR::ApplyArtObject);
-		REL::Relocation<func_t> func{ RELOCATION_ID(22289, 22769) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(22289, 22769) };
 		return func(this, a_artObject, a_duration, a_facingRef, a_faceTarget, a_attachToCamera, a_attachNode, a_interfaceEffect);
 	}
 
 	ShaderReferenceEffect* TESObjectREFR::ApplyEffectShader(TESEffectShader* a_effectShader, float a_duration, TESObjectREFR* a_facingRef, bool a_faceTarget, bool a_attachToCamera, NiAVObject* a_attachNode, bool a_interfaceEffect)
 	{
 		using func_t = decltype(&TESObjectREFR::ApplyEffectShader);
-		REL::Relocation<func_t> func{ RELOCATION_ID(19446, 19872) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19446, 19872) };
 		return func(this, a_effectShader, a_duration, a_facingRef, a_faceTarget, a_attachToCamera, a_attachNode, a_interfaceEffect);
 	}
 
 	bool TESObjectREFR::CanBeMoved()
 	{
 		using func_t = decltype(&TESObjectREFR::CanBeMoved);
-		REL::Relocation<func_t> func{ RELOCATION_ID(19244, 19670) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19244, 19670) };
 		return func(this);
 	}
 
@@ -102,7 +102,7 @@ namespace RE
 	void TESObjectREFR::Enable(bool a_resetInventory)
 	{
 		using func_t = decltype(&TESObjectREFR::Enable);
-		REL::Relocation<func_t> func{ RELOCATION_ID(19373, 19800) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19373, 19800) };
 		return func(this, a_resetInventory);
 	}
 
@@ -180,7 +180,7 @@ namespace RE
 	std::uint16_t TESObjectREFR::GetCalcLevel(bool a_adjustLevel) const
 	{
 		using func_t = decltype(&TESObjectREFR::GetCalcLevel);
-		REL::Relocation<func_t> func{ RELOCATION_ID(19800, 20205) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19800, 20205) };
 		return func(this, a_adjustLevel);
 	}
 
@@ -193,14 +193,14 @@ namespace RE
 	BGSLocation* TESObjectREFR::GetCurrentLocation() const
 	{
 		using func_t = decltype(&TESObjectREFR::GetCurrentLocation);
-		REL::Relocation<func_t> func{ RELOCATION_ID(19385, 19812) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19385, 19812) };
 		return func(this);
 	}
 
 	const char* TESObjectREFR::GetDisplayFullName()
 	{
 		using func_t = decltype(&TESObjectREFR::GetDisplayFullName);
-		REL::Relocation<func_t> func{ Offset::TESObjectREFR::GetDisplayFullName };
+		static REL::Relocation<func_t> func{ Offset::TESObjectREFR::GetDisplayFullName };
 		return func(this);
 	}
 
@@ -254,7 +254,7 @@ namespace RE
 	BGSEncounterZone* TESObjectREFR::GetEncounterZone() const
 	{
 		using func_t = decltype(&TESObjectREFR::GetEncounterZone);
-		REL::Relocation<func_t> func{ RELOCATION_ID(19797, 20202) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19797, 20202) };
 		return func(this);
 	}
 
@@ -448,7 +448,7 @@ namespace RE
 	REFR_LOCK* TESObjectREFR::GetLock() const
 	{
 		using func_t = decltype(&TESObjectREFR::GetLock);
-		REL::Relocation<func_t> func{ Offset::TESObjectREFR::GetLock };
+		static REL::Relocation<func_t> func{ Offset::TESObjectREFR::GetLock };
 		return func(this);
 	}
 
@@ -473,14 +473,14 @@ namespace RE
 	TESForm* TESObjectREFR::GetOwner() const
 	{
 		using func_t = decltype(&TESObjectREFR::GetOwner);
-		REL::Relocation<func_t> func{ Offset::TESObjectREFR::GetOwner };
+		static REL::Relocation<func_t> func{ Offset::TESObjectREFR::GetOwner };
 		return func(this);
 	}
 
 	float TESObjectREFR::GetScale() const
 	{
 		using func_t = decltype(&TESObjectREFR::GetScale);
-		REL::Relocation<func_t> func{ RELOCATION_ID(19238, 19664) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19238, 19664) };
 		return func(this);
 	}
 
@@ -503,14 +503,14 @@ namespace RE
 	std::uint32_t TESObjectREFR::GetStealValue(const InventoryEntryData* a_entryData, std::uint32_t a_numItems, bool a_useMult) const
 	{
 		using func_t = decltype(&TESObjectREFR::GetStealValue);
-		REL::Relocation<func_t> func{ Offset::TESObjectREFR::GetStealValue };
+		static REL::Relocation<func_t> func{ Offset::TESObjectREFR::GetStealValue };
 		return func(this, a_entryData, a_numItems, a_useMult);
 	}
 
 	void TESObjectREFR::GetTransform(NiTransform& a_transform) const
 	{
 		using func_t = decltype(&TESObjectREFR::GetTransform);
-		REL::Relocation<func_t> func{ RELOCATION_ID(19326, 19753) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19326, 19753) };
 		return func(this, a_transform);
 	}
 
@@ -537,7 +537,7 @@ namespace RE
 	float TESObjectREFR::GetWeightInContainer()
 	{
 		using func_t = decltype(&TESObjectREFR::GetWeightInContainer);
-		REL::Relocation<func_t> func{ RELOCATION_ID(19277, 19703) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19277, 19703) };
 		return func(this);
 	}
 
@@ -618,21 +618,21 @@ namespace RE
 	bool TESObjectREFR::HasQuestObject() const
 	{
 		using func_t = decltype(&TESObjectREFR::HasQuestObject);
-		REL::Relocation<func_t> func{ RELOCATION_ID(19201, 19627) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19201, 19627) };
 		return func(this);
 	}
 
 	void TESObjectREFR::InitChildActivates(TESObjectREFR* a_actionRef)
 	{
 		using func_t = decltype(&TESObjectREFR::InitChildActivates);
-		REL::Relocation<func_t> func{ RELOCATION_ID(19857, 20264) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19857, 20264) };
 		return func(this, a_actionRef);
 	}
 
 	bool TESObjectREFR::InitInventoryIfRequired(bool a_ignoreContainerExtraData)
 	{
 		using func_t = decltype(&TESObjectREFR::InitInventoryIfRequired);
-		REL::Relocation<func_t> func{ Offset::TESObjectREFR::InitInventoryIfRequired };
+		static REL::Relocation<func_t> func{ Offset::TESObjectREFR::InitInventoryIfRequired };
 		return func(this, a_ignoreContainerExtraData);
 	}
 
@@ -655,14 +655,14 @@ namespace RE
 	bool TESObjectREFR::IsAnOwner(const Actor* a_testOwner, bool a_useFaction, bool a_requiresOwner) const
 	{
 		using func_t = decltype(&TESObjectREFR::IsAnOwner);
-		REL::Relocation<func_t> func{ RELOCATION_ID(19805, 20210) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19805, 20210) };
 		return func(this, a_testOwner, a_useFaction, a_requiresOwner);
 	}
 
 	bool TESObjectREFR::IsCrimeToActivate()
 	{
 		using func_t = decltype(&TESObjectREFR::IsCrimeToActivate);
-		REL::Relocation<func_t> func{ RELOCATION_ID(19400, 19827) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19400, 19827) };
 		return func(this);
 	}
 
@@ -805,7 +805,7 @@ namespace RE
 	void TESObjectREFR::OpenContainer(std::int32_t a_openType) const
 	{
 		using func_t = decltype(&TESObjectREFR::OpenContainer);
-		REL::Relocation<func_t> func{ RELOCATION_ID(50211, 51140) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(50211, 51140) };
 		func(this, a_openType);
 	}
 
@@ -904,7 +904,7 @@ namespace RE
 	void TESObjectREFR::SetOwner(TESForm* a_owner)
 	{
 		using func_t = decltype(&TESObjectREFR::SetOwner);
-		REL::Relocation<func_t> func{ RELOCATION_ID(19793, 20198) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19793, 20198) };
 		return func(this, a_owner);
 	}
 
@@ -921,7 +921,7 @@ namespace RE
 	void TESObjectREFR::SetTemporary()
 	{
 		using func_t = decltype(&TESObjectREFR::SetTemporary);
-		REL::Relocation<func_t> func{ RELOCATION_ID(14485, 14642) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(14485, 14642) };
 		func(this);
 	}
 
@@ -939,21 +939,21 @@ namespace RE
 	InventoryChanges* TESObjectREFR::MakeInventoryChanges()
 	{
 		using func_t = decltype(&TESObjectREFR::MakeInventoryChanges);
-		REL::Relocation<func_t> func{ RELOCATION_ID(15802, 16040) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(15802, 16040) };
 		return func(this);
 	}
 
 	void TESObjectREFR::MoveTo_Impl(const ObjectRefHandle& a_targetHandle, TESObjectCELL* a_targetCell, TESWorldSpace* a_selfWorldSpace, const NiPoint3& a_position, const NiPoint3& a_rotation)
 	{
 		using func_t = decltype(&TESObjectREFR::MoveTo_Impl);
-		REL::Relocation<func_t> func{ Offset::TESObjectREFR::MoveTo };
+		static REL::Relocation<func_t> func{ Offset::TESObjectREFR::MoveTo };
 		return func(this, a_targetHandle, a_targetCell, a_selfWorldSpace, a_position, a_rotation);
 	}
 
 	void TESObjectREFR::PlayAnimation_Impl(NiControllerManager* a_manager, NiControllerSequence* a_toSeq, NiControllerSequence* a_fromSeq, bool a_arg4)
 	{
 		using func_t = decltype(&TESObjectREFR::PlayAnimation_Impl);
-		REL::Relocation<func_t> func{ Offset::TESObjectREFR::PlayAnimation };
+		static REL::Relocation<func_t> func{ Offset::TESObjectREFR::PlayAnimation };
 		return func(this, a_manager, a_toSeq, a_fromSeq, a_arg4);
 	}
 }

--- a/src/RE/T/TESObjectWEAP.cpp
+++ b/src/RE/T/TESObjectWEAP.cpp
@@ -37,7 +37,7 @@ namespace RE
 	NiAVObject* TESObjectWEAP::GetFireNode(NiAVObject* a_root) const
 	{
 		using func_t = decltype(&TESObjectWEAP::GetFireNode);
-		REL::Relocation<func_t> func{ RELOCATION_ID(17689, 18098) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(17689, 18098) };
 		return func(this, a_root);
 	}
 

--- a/src/RE/T/TESQuest.cpp
+++ b/src/RE/T/TESQuest.cpp
@@ -13,14 +13,14 @@ namespace RE
 	ObjectRefHandle& TESQuest::CreateRefHandleByAliasID(ObjectRefHandle& a_handle, std::uint32_t a_aliasID)
 	{
 		using func_t = decltype(&TESQuest::CreateRefHandleByAliasID);
-		REL::Relocation<func_t> func{ RELOCATION_ID(24537, 25066) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(24537, 25066) };
 		return func(this, a_handle, a_aliasID);
 	}
 
 	bool TESQuest::EnsureQuestStarted(bool& a_result, bool a_startNow)
 	{
 		using func_t = decltype(&TESQuest::EnsureQuestStarted);
-		REL::Relocation<func_t> func{ Offset::TESQuest::EnsureQuestStarted };
+		static REL::Relocation<func_t> func{ Offset::TESQuest::EnsureQuestStarted };
 		return func(this, a_result, a_startNow);
 	}
 
@@ -67,7 +67,7 @@ namespace RE
 	void TESQuest::Reset()
 	{
 		using func_t = decltype(&TESQuest::Reset);
-		REL::Relocation<func_t> func{ Offset::TESQuest::ResetQuest };
+		static REL::Relocation<func_t> func{ Offset::TESQuest::ResetQuest };
 		return func(this);
 	}
 

--- a/src/RE/T/TESTopicInfo.cpp
+++ b/src/RE/T/TESTopicInfo.cpp
@@ -12,7 +12,7 @@ namespace RE
 	void TESTopicInfo::ResponseData::PopulateResponseText(TESFile* a_file)
 	{
 		using func_t = decltype(&TESTopicInfo::ResponseData::PopulateResponseText);
-		REL::Relocation<func_t> func{ RELOCATION_ID(24985, 25491) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(24985, 25491) };
 		return func(this, a_file);
 	}
 

--- a/src/RE/T/TESWorldSpace.cpp
+++ b/src/RE/T/TESWorldSpace.cpp
@@ -10,7 +10,7 @@ namespace RE
 	TESObjectCELL* TESWorldSpace::GetSkyCell()
 	{
 		using func_t = decltype(&TESWorldSpace::GetSkyCell);
-		REL::Relocation<func_t> func{ RELOCATION_ID(20095, 20543) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(20095, 20543) };
 		return func(this);
 	}
 

--- a/src/RE/T/TaskQueueInterface.cpp
+++ b/src/RE/T/TaskQueueInterface.cpp
@@ -11,56 +11,56 @@ namespace RE
 	bool TaskQueueInterface::ShouldUseTaskQueue()
 	{
 		using func_t = decltype(&TaskQueueInterface::ShouldUseTaskQueue);
-		REL::Relocation<func_t> func{ RELOCATION_ID(38079, 39033) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(38079, 39033) };
 		return func();
 	}
 
 	void TaskQueueInterface::QueueNodeAttach(NiAVObject* a_obj, NiNode* a_root, bool a_arg3, bool a_arg4)
 	{
 		using func_t = decltype(&TaskQueueInterface::QueueNodeAttach);
-		REL::Relocation<func_t> func{ RELOCATION_ID(35922, 36897) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(35922, 36897) };
 		return func(this, a_obj, a_root, a_arg3, a_arg4);
 	}
 
 	void TaskQueueInterface::QueueNodeDetach(NiAVObject* a_obj)
 	{
 		using func_t = decltype(&TaskQueueInterface::QueueNodeDetach);
-		REL::Relocation<func_t> func{ RELOCATION_ID(35923, 36898) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(35923, 36898) };
 		return func(this, a_obj);
 	}
 
 	void TaskQueueInterface::QueueUpdateDestructibleObject(TESObjectREFR* a_refr, float a_damage, bool a_arg3, TESObjectREFR* a_cause)
 	{
 		using func_t = decltype(&TaskQueueInterface::QueueUpdateDestructibleObject);
-		REL::Relocation<func_t> func{ RELOCATION_ID(35934, 36909) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(35934, 36909) };
 		return func(this, a_refr, a_damage, a_arg3, a_cause);
 	}
 
 	void TaskQueueInterface::QueueAddRipple(float a_scale, const NiPoint3& a_pos)
 	{
 		using func_t = decltype(&TaskQueueInterface::QueueAddRipple);
-		REL::Relocation<func_t> func{ RELOCATION_ID(35978, 36953) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(35978, 36953) };
 		return func(this, a_scale, a_pos);
 	}
 
 	void TaskQueueInterface::QueueForceWeather(TESWeather* a_weather, bool a_forceOverride)
 	{
 		using func_t = decltype(&TaskQueueInterface::QueueForceWeather);
-		REL::Relocation<func_t> func{ RELOCATION_ID(35991, 36966) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(35991, 36966) };
 		return func(this, a_weather, a_forceOverride);
 	}
 
 	void TaskQueueInterface::QueueActorDisarm(ActorHandle& a_target, ActorHandle& a_caster)
 	{
 		using func_t = decltype(&TaskQueueInterface::QueueActorDisarm);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36010, 36985) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36010, 36985) };
 		return func(this, a_target, a_caster);
 	}
 
 	void TaskQueueInterface::QueueRemoveSpell(ActorHandle& a_actor, SpellItem* a_spellItem)
 	{
 		using func_t = decltype(&TaskQueueInterface::QueueRemoveSpell);
-		REL::Relocation<func_t> func{ RELOCATION_ID(35987, 36962) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(35987, 36962) };
 		return func(this, a_actor, a_spellItem);
 	}
 }

--- a/src/RE/U/UI3DSceneManager.cpp
+++ b/src/RE/U/UI3DSceneManager.cpp
@@ -16,35 +16,35 @@ namespace RE
 	void UI3DSceneManager::AttachChild(NiAVObject* a_obj, INTERFACE_LIGHT_SCHEME a_scheme)
 	{
 		using func_t = void (*)(UI3DSceneManager*, NiAVObject*, INTERFACE_LIGHT_SCHEME);
-		REL::Relocation<func_t> func{ RELOCATION_ID(51859, 52731) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(51859, 52731) };
 		return func(this, a_obj, a_scheme);
 	}
 
 	void UI3DSceneManager::DetachChild(NiAVObject* a_obj)
 	{
 		using func_t = decltype(&UI3DSceneManager::DetachChild);
-		REL::Relocation<func_t> func{ RELOCATION_ID(51861, 52733) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(51861, 52733) };
 		return func(this, a_obj);
 	}
 
 	void UI3DSceneManager::SetCameraFOV(float a_fov)
 	{
 		using func_t = decltype(&UI3DSceneManager::SetCameraFOV);
-		REL::Relocation<func_t> func{ RELOCATION_ID(51870, 52742) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(51870, 52742) };
 		return func(this, a_fov);
 	}
 
 	void UI3DSceneManager::SetCameraRotate(const NiMatrix3& a_rotate)
 	{
 		using func_t = decltype(&UI3DSceneManager::SetCameraRotate);
-		REL::Relocation<func_t> func{ RELOCATION_ID(51869, 52741) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(51869, 52741) };
 		return func(this, a_rotate);
 	}
 
 	void UI3DSceneManager::SetCameraPosition(const NiPoint3& a_pos)
 	{
 		using func_t = decltype(&UI3DSceneManager::SetCameraRotate);
-		REL::Relocation<func_t> func{ RELOCATION_ID(51867, 52739) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(51867, 52739) };
 		return func(this, a_pos);
 	}
 }

--- a/src/RE/U/UIBlurManager.cpp
+++ b/src/RE/U/UIBlurManager.cpp
@@ -11,14 +11,14 @@ namespace RE
 	void UIBlurManager::DecrementBlurCount()
 	{
 		using func_t = decltype(&UIBlurManager::DecrementBlurCount);
-		REL::Relocation<func_t> func{ Offset::UIBlurManager::DecrementBlurCount };
+		static REL::Relocation<func_t> func{ Offset::UIBlurManager::DecrementBlurCount };
 		return func(this);
 	}
 
 	void UIBlurManager::IncrementBlurCount()
 	{
 		using func_t = decltype(&UIBlurManager::IncrementBlurCount);
-		REL::Relocation<func_t> func{ Offset::UIBlurManager::IncrementBlurCount };
+		static REL::Relocation<func_t> func{ Offset::UIBlurManager::IncrementBlurCount };
 		return func(this);
 	}
 }

--- a/src/RE/U/UIMessageQueue.cpp
+++ b/src/RE/U/UIMessageQueue.cpp
@@ -14,21 +14,21 @@ namespace RE
 	void UIMessageQueue::AddMessage(const BSFixedString& a_menuName, UI_MESSAGE_TYPE a_type, IUIMessageData* a_data)
 	{
 		using func_t = decltype(&UIMessageQueue::AddMessage);
-		REL::Relocation<func_t> func{ Offset::UIMessageQueue::AddMessage };
+		static REL::Relocation<func_t> func{ Offset::UIMessageQueue::AddMessage };
 		return func(this, a_menuName, a_type, a_data);
 	}
 
 	IUIMessageData* UIMessageQueue::CreateUIMessageData(const BSFixedString& a_name)
 	{
 		using func_t = decltype(&UIMessageQueue::CreateUIMessageData);
-		REL::Relocation<func_t> func{ Offset::UIMessageQueue::CreateUIMessageData };
+		static REL::Relocation<func_t> func{ Offset::UIMessageQueue::CreateUIMessageData };
 		return func(this, a_name);
 	}
 
 	void UIMessageQueue::ProcessCommands()
 	{
 		using func_t = decltype(&UIMessageQueue::ProcessCommands);
-		REL::Relocation<func_t> func{ Offset::UIMessageQueue::ProcessCommands };
+		static REL::Relocation<func_t> func{ Offset::UIMessageQueue::ProcessCommands };
 		return func(this);
 	}
 }

--- a/src/RE/U/UnlinkedTypes.cpp
+++ b/src/RE/U/UnlinkedTypes.cpp
@@ -19,14 +19,14 @@ namespace RE
 			void Object::Dtor()
 			{
 				using func_t = decltype(&Object::Dtor);
-				REL::Relocation<func_t> func{ RELOCATION_ID(98654, 105309) };
+				static REL::Relocation<func_t> func{ RELOCATION_ID(98654, 105309) };
 				return func(this);
 			}
 
 			Object* Object::Ctor()
 			{
 				using func_t = decltype(&Object::Ctor);
-				REL::Relocation<func_t> func{ RELOCATION_ID(98759, 105410) };
+				static REL::Relocation<func_t> func{ RELOCATION_ID(98759, 105410) };
 				return func(this);
 			}
 


### PR DESCRIPTION
Regex replaces all `REL::Relocation<func_t> func...` with `static REL::Relocation<func_t> func...`.

The reason for this change is when we checked performance for community-shaders when we call some of these functions every frame it showed a lot of calls to `REL::IDDatabase::id2offset`. And there is no reason to reinit the relocations, so these should all be static.