### PR TITLE
NiMatrix QoL funcs & missing VTables

### DIFF
--- a/include/RE/A/ActorValueMeter.h
+++ b/include/RE/A/ActorValueMeter.h
@@ -9,6 +9,7 @@ namespace RE
 	{
 	public:
 		inline static constexpr auto RTTI = RTTI_ActorValueMeter;
+		inline static constexpr auto VTABLE = VTABLE_ActorValueMeter;
 
 		~ActorValueMeter() override;  // 00
 

--- a/include/RE/A/ActorValueOwner.h
+++ b/include/RE/A/ActorValueOwner.h
@@ -8,6 +8,7 @@ namespace RE
 	{
 	public:
 		inline static constexpr auto RTTI = RTTI_ActorValueOwner;
+		inline static constexpr auto VTABLE = VTABLE_ActorValueOwner;
 
 		virtual ~ActorValueOwner();  // 00
 

--- a/include/RE/N/NiMatrix3.h
+++ b/include/RE/N/NiMatrix3.h
@@ -24,6 +24,10 @@ namespace RE
 		NiMatrix3(float a_x, float a_y, float a_z);
 		NiMatrix3(const NiPoint3& a_x, const NiPoint3& a_y, const NiPoint3& a_z);
 
+		NiPoint3  GetVectorX() const;
+		NiPoint3  GetVectorY() const;
+		NiPoint3  GetVectorZ() const;
+
 		bool      ToEulerAnglesXYZ(NiPoint3& a_angle) const;
 		bool      ToEulerAnglesXYZ(float& a_xAngle, float& a_yAngle, float& a_zAngle) const;
 		void      EulerAnglesToAxesZXY(const NiPoint3& a_angle);

--- a/src/RE/N/NiMatrix3.cpp
+++ b/src/RE/N/NiMatrix3.cpp
@@ -28,6 +28,21 @@ namespace RE
 		entry[2][2] = a_z.z;
 	}
 
+	NiPoint3 NiMatrix3::GetVectorX() const
+	{
+		return NiPoint3{ entry[0][0], entry[1][0], entry[2][0] };
+	}
+
+	NiPoint3 NiMatrix3::GetVectorY() const
+	{
+		return NiPoint3{ entry[0][1], entry[1][1], entry[2][1] };
+	}
+
+	NiPoint3 NiMatrix3::GetVectorZ() const
+	{
+		return NiPoint3{ entry[0][2], entry[1][2], entry[2][2] };
+	}
+
 	bool NiMatrix3::ToEulerAnglesXYZ(NiPoint3& a_angle) const
 	{
 		return ToEulerAnglesXYZ(a_angle.x, a_angle.y, a_angle.z);


### PR DESCRIPTION
3 QoL methods to extract the X,Y, Z column vectors from a NiMatrix, and ActorValueMeter & ActorValueOwner were missing their VTable declarations