### PR TITLE
Update MapMenu runtime-data members

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -1196,6 +1196,7 @@ set(SOURCES
 	include/RE/M/MapInputHandler.h
 	include/RE/M/MapLookHandler.h
 	include/RE/M/MapMenu.h
+	include/RE/M/MapMenuMarker.h
 	include/RE/M/MapMoveHandler.h
 	include/RE/M/MapZoomHandler.h
 	include/RE/M/MarkerUsedData.h

--- a/include/RE/L/LocalMapMenu.h
+++ b/include/RE/L/LocalMapMenu.h
@@ -15,6 +15,7 @@ namespace RE
 	class BSShaderAccumulator;
 	class NiCamera;
 	class NiNode;
+	struct MapMenuMarker;
 
 	struct LocalMapMenu
 	{
@@ -73,7 +74,7 @@ namespace RE
 		static_assert(sizeof(InputHandler) == 0x18);
 
 		// members
-		BSTArray<void*>               unk00000;             // 00000
+		BSTArray<MapMenuMarker>       mapMarkers;           // 00000
 		GFxValue                      unk00018;             // 00018
 		float                         unk00030;             // 00030
 		float                         unk00034;             // 00034
@@ -81,11 +82,15 @@ namespace RE
 		float                         unk0003C;             // 0003C
 		LocalMapCullingProcess        localCullingProcess;  // 00040
 		BSScaleformExternalTexture    unk303A0;             // 303A0
-		GFxValue                      unk303B8;             // 303B8
-		GFxValue                      unk303D0;             // 303D0
+		GFxValue                      localMapMovie;        // 303B8
+		GFxValue                      mapMovie;             // 303D0
 		void*                         unk303E8;             // 303E8
 		BSTSmartPointer<InputHandler> unk303F0;             // 303F0
-		std::uint64_t                 unk303F8;             // 303F8
+		std::int32_t                  selectedMarker;       // 303F8
+		bool                          showingMap;           // 303FC
+		bool                          dragging;             // 303FD
+		bool                          controlsReady;        // 303FE
+		std::uint8_t                  unk303FF;             // 303FF
 	};
 	static_assert(sizeof(LocalMapMenu) == 0x30400);
 }

--- a/include/RE/M/MainMenu.h
+++ b/include/RE/M/MainMenu.h
@@ -9,6 +9,7 @@ namespace RE
 {
 	class BSSaveDataEvent;
 	class BSSystemEvent;
+	struct MapMenuMarker;
 
 	// menuDepth = 0
 	// flags = kPausesGame | kDisablePauseMenu | kRequiresUpdate | kUpdateUsesCursor | kApplicationMenu

--- a/include/RE/M/MapMenu.h
+++ b/include/RE/M/MapMenu.h
@@ -57,18 +57,21 @@ namespace RE
 		LocalMapMenu                    localMapMenu;          // 00060
 		RefHandle                       unk30460;              // 30460
 		NiPoint3                        playerMarkerPosition;  // 30464
-		BSTArray<void*>                 unk30470;              // 30470
-		BSTArray<void*>                 unk30488;              // 30488
+		BSTArray<MapMenuMarker>         mapMarkers;            // 30470
+		BSTArray<GFxValue>              markerData;            // 30488
 		MapCamera                       camera;                // 304A0
 		std::uint64_t                   unk30530;              // 30530
 		TESWorldSpace*                  worldSpace;            // 30538
-		GFxValue                        unk30540;              // 30540
-		std::uint32_t                   unk30558;              // 30558
+		GFxValue                        mapMovie;              // 30540
+		std::int32_t                    selectedMarker;        // 30558
 		NiPoint3                        cameraPickOrigin;      // 3055C
 		NiPoint3                        cameraPickDirection;   // 30568
 		BSSoundHandle                   unk30574;              // 30574
 		std::uint64_t                   unk30580;              // 30580
-		std::uint64_t                   unk30588;              // 30588
+		std::uint32_t                   unk30588;              // 30588
+		bool                            controlsReady;         // 3058C
+		std::uint8_t                    unk3058D;              // 3058D
+		std::uint16_t                   unk3058E;              // 3058E
 		std::uint64_t                   unk30590;              // 30590
 	};
 	static_assert(sizeof(MapMenu) == 0x30598);

--- a/include/RE/M/MapMenuMarker.h
+++ b/include/RE/M/MapMenuMarker.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "RE/T/TESForm.h"
+#include "RE/T/TESFullName.h"
+
+namespace RE
+{
+	struct MapMenuMarker
+	{
+		TESFullName*  fullName;      // 00
+		RefHandle     ref;           // 08
+		std::uint32_t pad0C;         // 0C
+		const char*   customMarker;  // 10
+		std::uint32_t type;          // 18
+		std::uint32_t door;          // 1C
+		std::int32_t  index;         // 20
+		std::uint32_t pad24;         // 24
+		TESForm*      form;          // 28
+		std::uint8_t  unk30;         // 30
+		std::uint8_t  pad31;         // 31
+		std::uint16_t pad32;         // 32
+		std::uint32_t pad34;         // 34
+	};
+	static_assert(sizeof(MapMenuMarker) == 0x38);
+}

--- a/include/RE/Skyrim.h
+++ b/include/RE/Skyrim.h
@@ -1198,6 +1198,7 @@
 #include "RE/M/MapInputHandler.h"
 #include "RE/M/MapLookHandler.h"
 #include "RE/M/MapMenu.h"
+#include "RE/M/MapMenuMarker.h"
 #include "RE/M/MapMoveHandler.h"
 #include "RE/M/MapZoomHandler.h"
 #include "RE/M/MarkerUsedData.h"


### PR DESCRIPTION
Members updated in this commit are used in MapMenu.as and LocalMap.as. The BSTArray<GFxValue> is the content of WorldMap.MarkerData, and changes depending on the function being called (CreateMarkers/RefreshMarkers). The cameraPickDirection seems to be 3 floats used to calculate the custom marker position based on cameraPickOrigin, updated when the custom marker is created but only when the map is moved.