### PR TITLE
remove assertion in pack/unpack.h

### DIFF
--- a/include/RE/P/PackUnpackImpl.h
+++ b/include/RE/P/PackUnpackImpl.h
@@ -81,7 +81,6 @@ namespace RE
 
 			auto array = a_src->GetArray();
 			if (!array) {
-				assert(false);
 				return container;
 			}
 


### PR DESCRIPTION
The assertion here is (usually) caused when passing an empty/uninitialized array from Papyrus to C++, returning an empty container sounds like an expected outcome here (no assertion needed)