### PR TITLE
feat: xmake | support plugin installation and packaging

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -1,9 +1,6 @@
 -- set minimum xmake version
 set_xmakever("2.8.2")
 
--- make extras available
-includes("xmake-extra.lua")
-
 -- set project
 set_project("commonlibsse")
 set_arch("x64")
@@ -12,7 +9,10 @@ set_warnings("allextra")
 set_encodings("utf-8")
 
 -- add rules
-add_rules("mode.debug", "mode.release")
+add_rules("mode.debug", "mode.releasedbg")
+
+-- make extras available
+includes("xmake-extra.lua")
 
 -- define options
 option("skyrim_ae")
@@ -39,6 +39,9 @@ end
 target("commonlibsse")
     -- set target kind
     set_kind("static")
+
+    -- set build by default
+    set_default(os.scriptdir() == os.projectdir())
 
     -- add packages
     add_packages("rsm-binary-io", "spdlog", { public = true })


### PR DESCRIPTION
- when you build (or run `xmake install`) it will search for the environment variable `XSE_TES5_MODS_PATH` or `XSE_TES5_GAME_PATH` and copy install files (by default ".dll" and ".pdb") to the root path listed. More files can be added using `add_installfiles`.
  - the install path above can be overwritten using `set_installdir`
- when you run `xmake package` it will package the same files from above into a zip archive named after the target and the version.
- these events can be overwritten on a per-target basis if you wish to make your own install/package logic.