### PR TITLE
Research: TESObjectWEAP fields (hopefully not a broken PR this time)

### DIFF
--- a/include/RE/T/TESObjectWEAP.h
+++ b/include/RE/T/TESObjectWEAP.h
@@ -39,19 +39,25 @@ namespace RE
 		kPeriodicSawtooth = 3
 	};
 
-	enum class WEAPON_TYPE
+	struct WeaponTypes
 	{
-		kHandToHandMelee = 0,
-		kOneHandSword = 1,
-		kOneHandDagger = 2,
-		kOneHandAxe = 3,
-		kOneHandMace = 4,
-		kTwoHandSword = 5,
-		kTwoHandAxe = 6,
-		kBow = 7,
-		kStaff = 8,
-		kCrossbow = 9
+		enum WEAPON_TYPE : std::uint32_t
+		{
+			kHandToHandMelee = 0,
+			kOneHandSword = 1,
+			kOneHandDagger = 2,
+			kOneHandAxe = 3,
+			kOneHandMace = 4,
+			kTwoHandSword = 5,
+			kTwoHandAxe = 6,
+			kBow = 7,
+			kStaff = 8,
+			kCrossbow = 9,
+
+			kTotal = 10
+		};
 	};
+	using WEAPON_TYPE = WeaponTypes::WEAPON_TYPE;
 
 	class TESObjectWEAP :
 		public TESBoundObject,             // 000
@@ -73,6 +79,7 @@ namespace RE
 	{
 	public:
 		inline static constexpr auto RTTI = RTTI_TESObjectWEAP;
+		inline static constexpr auto VTABLE = VTABLE_TESObjectWEAP;
 		inline static constexpr auto FORMTYPE = FormType::Weapon;
 
 		struct RecordFlags
@@ -159,24 +166,24 @@ namespace RE
 			};
 
 			// members
-			RangedData*                                        rangedData;           // 00
-			float                                              speed;                // 08
-			float                                              reach;                // 0C
-			float                                              minRange;             // 10
-			float                                              maxRange;             // 14
-			float                                              animationAttackMult;  // 18
-			float                                              damageToWeaponMult;   // 1C - used in (unused?) condition calculations if Flag2::kOverridesConditionDamage is set
-			float                                              staggerValue;         // 20
-			stl::enumeration<WEAPONHITBEHAVIOR, std::uint32_t> hitBehavior;          // 24
-			stl::enumeration<ActorValue, std::uint32_t>        skill;                // 28
-			stl::enumeration<ActorValue, std::uint32_t>        resistance;           // 2C
-			stl::enumeration<Flag2, std::uint16_t>             flags2;               // 30
-			std::uint8_t                                       baseVATSToHitChance;  // 32
-			stl::enumeration<AttackAnimation, std::uint8_t>    attackAnimation;      // 33
-			stl::enumeration<ActorValue, std::uint8_t>         embeddedWeaponAV;     // 34 - unused
-			stl::enumeration<WEAPON_TYPE, std::uint8_t>        animationType;        // 35
-			stl::enumeration<Flag, std::uint8_t>               flags;                // 36
-			std::uint8_t                                       unk37;                // 37
+			RangedData*                                    rangedData;           // 00
+			float                                          speed;                // 08
+			float                                          reach;                // 0C
+			float                                          minRange;             // 10
+			float                                          maxRange;             // 14
+			float                                          animationAttackMult;  // 18
+			float                                          damageToWeaponMult;   // 1C - used in (unused?) condition calculations if Flag2::kOverridesConditionDamage is set
+			float                                          staggerValue;         // 20
+			REX::EnumSet<WEAPONHITBEHAVIOR, std::uint32_t> hitBehavior;          // 24
+			REX::EnumSet<ActorValue, std::uint32_t>        skill;                // 28
+			REX::EnumSet<ActorValue, std::uint32_t>        resistance;           // 2C
+			REX::EnumSet<Flag2, std::uint16_t>             flags2;               // 30
+			std::uint8_t                                   baseVATSToHitChance;  // 32
+			REX::EnumSet<AttackAnimation, std::uint8_t>    attackAnimation;      // 33
+			REX::EnumSet<ActorValue, std::uint8_t>         embeddedWeaponAV;     // 34 - unused
+			REX::EnumSet<WEAPON_TYPE, std::uint8_t>        animationType;        // 35
+			REX::EnumSet<Flag, std::uint8_t>               flags;                // 36
+			std::uint8_t                                   unk37;                // 37
 		};
 		static_assert(sizeof(Data) == 0x38);
 
@@ -190,13 +197,13 @@ namespace RE
 			};
 
 			// members
-			float                                prcntMult;  // 00
-			std::uint32_t                        pad04;      // 04
-			SpellItem*                           effect;     // 08
-			std::uint16_t                        damage;     // 10
-			stl::enumeration<Flag, std::uint8_t> flags;      // 12
-			std::uint8_t                         pad13;      // 13
-			std::uint32_t                        pad14;      // 14
+			float                            prcntMult;  // 00
+			std::uint32_t                    pad04;      // 04
+			SpellItem*                       effect;     // 08
+			std::uint16_t                    damage;     // 10
+			REX::EnumSet<Flag, std::uint8_t> flags;      // 12
+			std::uint8_t                     pad13;      // 13
+			std::uint32_t                    pad14;      // 14
 		};
 		static_assert(sizeof(CriticalData) == 0x18);
 
@@ -231,6 +238,7 @@ namespace RE
 		[[nodiscard]] float         GetMinRange() const;
 		[[nodiscard]] float         GetMaxRange() const;
 		[[nodiscard]] std::uint16_t GetCritDamage() const;
+		NiAVObject*                 GetFireNode(NiAVObject* a_root) const;
 		void                        GetNodeName(char* a_dstBuff) const;
 		[[nodiscard]] WEAPON_TYPE   GetWeaponType() const;
 		[[nodiscard]] bool          IsBound() const;
@@ -248,22 +256,22 @@ namespace RE
 		[[nodiscard]] bool          IsCrossbow() const;
 
 		// members
-		Data                                         weaponData;              // 168 - DNAM
-		CriticalData                                 criticalData;            // 1A0 - CRDT
-		ScopeArt*                                    scopeArt;                // 1B8
-		BGSSoundDescriptorForm*                      attackSound;             // 1C0 - SNAM
-		BGSSoundDescriptorForm*                      attackSound2D;           // 1C8 - XNAM
-		BGSSoundDescriptorForm*                      attackLoopSound;         // 1D0 - NAM7
-		BGSSoundDescriptorForm*                      attackFailSound;         // 1D8 - TNAM
-		BGSSoundDescriptorForm*                      idleSound;               // 1E0 - UNAM
-		BGSSoundDescriptorForm*                      equipSound;              // 1E8 - NAM9
-		BGSSoundDescriptorForm*                      unequipSound;            // 1F0 - NAM8
-		BGSImpactDataSet*                            impactDataSet;           // 1F8
-		TESObjectSTAT*                               firstPersonModelObject;  // 200 - WNAM
-		TESObjectWEAP*                               templateWeapon;          // 208 - CNAM
-		BSFixedString                                embeddedNode;            // 210
-		stl::enumeration<SOUND_LEVEL, std::uint32_t> soundLevel;              // 218 - VNAM
-		std::uint32_t                                pad21C;                  // 21C
+		Data                                     weaponData;              // 168 - DNAM
+		CriticalData                             criticalData;            // 1A0 - CRDT
+		ScopeArt*                                scopeArt;                // 1B8
+		BGSSoundDescriptorForm*                  attackSound;             // 1C0 - SNAM
+		BGSSoundDescriptorForm*                  attackSound2D;           // 1C8 - XNAM
+		BGSSoundDescriptorForm*                  attackLoopSound;         // 1D0 - NAM7
+		BGSSoundDescriptorForm*                  attackFailSound;         // 1D8 - TNAM
+		BGSSoundDescriptorForm*                  idleSound;               // 1E0 - UNAM
+		BGSSoundDescriptorForm*                  equipSound;              // 1E8 - NAM9
+		BGSSoundDescriptorForm*                  unequipSound;            // 1F0 - NAM8
+		BGSImpactDataSet*                        impactDataSet;           // 1F8
+		TESObjectSTAT*                           firstPersonModelObject;  // 200 - WNAM
+		TESObjectWEAP*                           templateWeapon;          // 208 - CNAM
+		BSFixedString                            embeddedNode;            // 210
+		REX::EnumSet<SOUND_LEVEL, std::uint32_t> soundLevel;              // 218 - VNAM
+		std::uint32_t                            pad21C;                  // 21C
 	};
 	static_assert(sizeof(TESObjectWEAP) == 0x220);
 }

--- a/include/RE/T/TESObjectWEAP.h
+++ b/include/RE/T/TESObjectWEAP.h
@@ -39,25 +39,19 @@ namespace RE
 		kPeriodicSawtooth = 3
 	};
 
-	struct WeaponTypes
+	enum class WEAPON_TYPE
 	{
-		enum WEAPON_TYPE : std::uint32_t
-		{
-			kHandToHandMelee = 0,
-			kOneHandSword = 1,
-			kOneHandDagger = 2,
-			kOneHandAxe = 3,
-			kOneHandMace = 4,
-			kTwoHandSword = 5,
-			kTwoHandAxe = 6,
-			kBow = 7,
-			kStaff = 8,
-			kCrossbow = 9,
-
-			kTotal = 10
-		};
+		kHandToHandMelee = 0,
+		kOneHandSword = 1,
+		kOneHandDagger = 2,
+		kOneHandAxe = 3,
+		kOneHandMace = 4,
+		kTwoHandSword = 5,
+		kTwoHandAxe = 6,
+		kBow = 7,
+		kStaff = 8,
+		kCrossbow = 9
 	};
-	using WEAPON_TYPE = WeaponTypes::WEAPON_TYPE;
 
 	class TESObjectWEAP :
 		public TESBoundObject,             // 000
@@ -79,7 +73,6 @@ namespace RE
 	{
 	public:
 		inline static constexpr auto RTTI = RTTI_TESObjectWEAP;
-		inline static constexpr auto VTABLE = VTABLE_TESObjectWEAP;
 		inline static constexpr auto FORMTYPE = FormType::Weapon;
 
 		struct RecordFlags
@@ -87,6 +80,7 @@ namespace RE
 			enum RecordFlag : std::uint32_t
 			{
 				kNonPlayable = 1 << 2,
+				kHasInheritedFromTemplate = 1 << 3, // cleared on load; set by relevant processing in InitItemImpl
 				kDeleted = 1 << 5,
 				kIgnored = 1 << 12
 			};
@@ -96,15 +90,15 @@ namespace RE
 		{
 		public:
 			// members
-			float                                              sightFOV;                        // 00
-			float                                              unk04;                           // 04
-			float                                              firingRumbleLeftMotorStrength;   // 08
-			float                                              firingRumbleRightMotorStrength;  // 0C
-			float                                              firingRumbleDuration;            // 10
-			REX::EnumSet<WEAPON_RUMBLE_PATTERN, std::uint32_t> rumblePattern;                   // 14
-			std::int8_t                                        numProjectiles;                  // 18
-			std::uint8_t                                       pad19;                           // 19
-			std::uint16_t                                      pad1A;                           // 1A
+			float         sightFOV;                        // 00
+			float         fireRate;                        // 04 - Fallout leftover?
+			float         firingRumbleLeftMotorStrength;   // 08
+			float         firingRumbleRightMotorStrength;  // 0C
+			float         firingRumbleDuration;            // 10
+			float         attackShotsPerSec;               // 14 - Fallout leftover?
+			std::int8_t   numProjectiles;                  // 18
+			std::uint8_t  pad19;                           // 19
+			std::uint16_t pad1A;                           // 1A
 		};
 		static_assert(sizeof(RangedData) == 0x1C);
 
@@ -120,6 +114,7 @@ namespace RE
 				kMinorCrime = 1 << 4,
 				kRangeFixed = 1 << 5,
 				kNotUsedInNormalCombat = 1 << 6,
+				kOverridesConditionDamage = 1 << 7, 
 				kDontUse3rdPersonISAnim = 1 << 8,  // unused
 				kBurstShot = 1 << 9,
 				kRumbleAlternate = 1 << 10,
@@ -164,24 +159,24 @@ namespace RE
 			};
 
 			// members
-			RangedData*                                    rangedData;           // 00
-			float                                          speed;                // 08
-			float                                          reach;                // 0C
-			float                                          minRange;             // 10
-			float                                          maxRange;             // 14
-			float                                          animationAttackMult;  // 18
-			float                                          unk1C;                // 1C
-			float                                          staggerValue;         // 20
-			REX::EnumSet<WEAPONHITBEHAVIOR, std::uint32_t> hitBehavior;          // 24
-			REX::EnumSet<ActorValue, std::uint32_t>        skill;                // 28
-			REX::EnumSet<ActorValue, std::uint32_t>        resistance;           // 2C
-			REX::EnumSet<Flag2, std::uint16_t>             flags2;               // 30
-			std::uint8_t                                   baseVATSToHitChance;  // 32
-			REX::EnumSet<AttackAnimation, std::uint8_t>    attackAnimation;      // 33
-			REX::EnumSet<ActorValue, std::uint8_t>         embeddedWeaponAV;     // 34 - unused
-			REX::EnumSet<WEAPON_TYPE, std::uint8_t>        animationType;        // 35
-			REX::EnumSet<Flag, std::uint8_t>               flags;                // 36
-			std::uint8_t                                   unk37;                // 37
+			RangedData*                                        rangedData;           // 00
+			float                                              speed;                // 08
+			float                                              reach;                // 0C
+			float                                              minRange;             // 10
+			float                                              maxRange;             // 14
+			float                                              animationAttackMult;  // 18
+			float                                              damageToWeaponMult;   // 1C - used in (unused?) condition calculations if Flag2::kOverridesConditionDamage is set
+			float                                              staggerValue;         // 20
+			stl::enumeration<WEAPONHITBEHAVIOR, std::uint32_t> hitBehavior;          // 24
+			stl::enumeration<ActorValue, std::uint32_t>        skill;                // 28
+			stl::enumeration<ActorValue, std::uint32_t>        resistance;           // 2C
+			stl::enumeration<Flag2, std::uint16_t>             flags2;               // 30
+			std::uint8_t                                       baseVATSToHitChance;  // 32
+			stl::enumeration<AttackAnimation, std::uint8_t>    attackAnimation;      // 33
+			stl::enumeration<ActorValue, std::uint8_t>         embeddedWeaponAV;     // 34 - unused
+			stl::enumeration<WEAPON_TYPE, std::uint8_t>        animationType;        // 35
+			stl::enumeration<Flag, std::uint8_t>               flags;                // 36
+			std::uint8_t                                       unk37;                // 37
 		};
 		static_assert(sizeof(Data) == 0x38);
 
@@ -195,24 +190,24 @@ namespace RE
 			};
 
 			// members
-			float                            prcntMult;  // 00
-			std::uint32_t                    pad04;      // 04
-			SpellItem*                       effect;     // 08
-			std::uint16_t                    damage;     // 10
-			REX::EnumSet<Flag, std::uint8_t> flags;      // 12
-			std::uint8_t                     pad13;      // 13
-			std::uint32_t                    pad14;      // 14
+			float                                prcntMult;  // 00
+			std::uint32_t                        pad04;      // 04
+			SpellItem*                           effect;     // 08
+			std::uint16_t                        damage;     // 10
+			stl::enumeration<Flag, std::uint8_t> flags;      // 12
+			std::uint8_t                         pad13;      // 13
+			std::uint32_t                        pad14;      // 14
 		};
 		static_assert(sizeof(CriticalData) == 0x18);
 
-		struct Unk1B8
+		struct ScopeArt
 		{
 		public:
 			// members
-			TESModel         unk00;  // 00
-			TESEffectShader* unk28;  // 28
+			TESModel         unk00;  // 00 - MOD3 and friends
+			TESEffectShader* unk28;  // 28 - EIDT
 		};
-		static_assert(sizeof(Unk1B8) == 0x30);
+		static_assert(sizeof(ScopeArt) == 0x30);
 
 		~TESObjectWEAP() override;  // 00
 
@@ -236,7 +231,6 @@ namespace RE
 		[[nodiscard]] float         GetMinRange() const;
 		[[nodiscard]] float         GetMaxRange() const;
 		[[nodiscard]] std::uint16_t GetCritDamage() const;
-		NiAVObject*                 GetFireNode(NiAVObject* a_root) const;
 		void                        GetNodeName(char* a_dstBuff) const;
 		[[nodiscard]] WEAPON_TYPE   GetWeaponType() const;
 		[[nodiscard]] bool          IsBound() const;
@@ -254,22 +248,22 @@ namespace RE
 		[[nodiscard]] bool          IsCrossbow() const;
 
 		// members
-		Data                                     weaponData;              // 168 - DNAM
-		CriticalData                             criticalData;            // 1A0 - CRDT
-		Unk1B8*                                  unk1B8;                  // 1B8
-		BGSSoundDescriptorForm*                  attackSound;             // 1C0 - SNAM
-		BGSSoundDescriptorForm*                  attackSound2D;           // 1C8 - XNAM
-		BGSSoundDescriptorForm*                  attackLoopSound;         // 1D0 - NAM7
-		BGSSoundDescriptorForm*                  attackFailSound;         // 1D8 - TNAM
-		BGSSoundDescriptorForm*                  idleSound;               // 1E0 - UNAM
-		BGSSoundDescriptorForm*                  equipSound;              // 1E8 - NAM9
-		BGSSoundDescriptorForm*                  unequipSound;            // 1F0 - NAM8
-		BGSImpactDataSet*                        impactDataSet;           // 1F8
-		TESObjectSTAT*                           firstPersonModelObject;  // 200 - WNAM
-		TESObjectWEAP*                           templateWeapon;          // 208 - CNAM
-		BSFixedString                            embeddedNode;            // 210
-		REX::EnumSet<SOUND_LEVEL, std::uint32_t> soundLevel;              // 218 - VNAM
-		std::uint32_t                            pad21C;                  // 21C
+		Data                                         weaponData;              // 168 - DNAM
+		CriticalData                                 criticalData;            // 1A0 - CRDT
+		ScopeArt*                                    scopeArt;                // 1B8
+		BGSSoundDescriptorForm*                      attackSound;             // 1C0 - SNAM
+		BGSSoundDescriptorForm*                      attackSound2D;           // 1C8 - XNAM
+		BGSSoundDescriptorForm*                      attackLoopSound;         // 1D0 - NAM7
+		BGSSoundDescriptorForm*                      attackFailSound;         // 1D8 - TNAM
+		BGSSoundDescriptorForm*                      idleSound;               // 1E0 - UNAM
+		BGSSoundDescriptorForm*                      equipSound;              // 1E8 - NAM9
+		BGSSoundDescriptorForm*                      unequipSound;            // 1F0 - NAM8
+		BGSImpactDataSet*                            impactDataSet;           // 1F8
+		TESObjectSTAT*                               firstPersonModelObject;  // 200 - WNAM
+		TESObjectWEAP*                               templateWeapon;          // 208 - CNAM
+		BSFixedString                                embeddedNode;            // 210
+		stl::enumeration<SOUND_LEVEL, std::uint32_t> soundLevel;              // 218 - VNAM
+		std::uint32_t                                pad21C;                  // 21C
 	};
 	static_assert(sizeof(TESObjectWEAP) == 0x220);
 }


### PR DESCRIPTION
Identified several fields as Fallout 3 leftovers by studying the TESObjectWEAP/DNAM loading code in both LE and SSE. The game is capable of loading FO3-era records (record version 16 and lower) and the structure it uses for those matches xEdit's definitions for Fallout 3 WEAP/DNAM.

In particular, the field currently known as `rumblePattern` is misidentified. The WEAP/DNAM loaders compare the loaded `RangedData` fields to their defaults to see if it should bother creating a `RangedData` in memory, and `rumblePattern` is compared as a float (FPU opcodes in LE; UCOMISS in SSE). The old-format loader loads this field from the position that "Attack Shots/Sec" has in Fallout 3; meanwhile, the "Rumble - Pattern" field in FO3 is never retained. I've adjusted the field, but haven't deleted the rumble enum since that could possibly be used elsewhere.

The `Flag2` for overriding damage-to-weapon multipliers is something I found in prior research for LE years ago. The game computes how much condition damage a weapon would take (search for references to game settings `fDamageToWeaponMeleeMult` and `fDamageToWeaponGunMult`), and there, one can see this `Flag2` used to override the game settings. Not sure if the result of the condition damage calculation is ever actually applied anywhere. I suspect it isn't.

----

My previous attempt at submitting this PR (#141) was through GitHub Desktop, and for some reason included dozens of unrelated commits. This attempt is being made through GitHub's website, which at the time of my writing this lists only my one (1) commit as being part of this PR. I'm going to close the previous PR and submit this one, and hopefully it won't end up broken. If it does, then I'll wait for help before I try again.