### PR TITLE
perf: make more relocations static

### DIFF
--- a/include/RE/A/ActorValueList.h
+++ b/include/RE/A/ActorValueList.h
@@ -10,7 +10,7 @@ namespace RE
 	public:
 		[[nodiscard]] static ActorValueList* GetSingleton()
 		{
-			REL::Relocation<ActorValueList**> singleton{ RELOCATION_ID(514139, 400267) };
+			static REL::Relocation<ActorValueList**> singleton{ RELOCATION_ID(514139, 400267) };
 			return *singleton;
 		}
 

--- a/include/RE/A/AnimationFileManagerSingleton.h
+++ b/include/RE/A/AnimationFileManagerSingleton.h
@@ -52,7 +52,7 @@ namespace RE
 
 		[[nodiscard]] static AnimationFileManagerSingleton* GetSingleton()
 		{
-			REL::Relocation<AnimationFileManagerSingleton**> singleton{ RELOCATION_ID(520994, 407512) };
+			static REL::Relocation<AnimationFileManagerSingleton**> singleton{ RELOCATION_ID(520994, 407512) };
 			return *singleton;
 		}
 

--- a/include/RE/A/AnimationObjects.h
+++ b/include/RE/A/AnimationObjects.h
@@ -32,7 +32,7 @@ namespace RE
 	public:
 		[[nodiscard]] static AnimationObjects* GetSingleton()
 		{
-			REL::Relocation<AnimationObjects**> singleton{ RELOCATION_ID(514179, 400328) };
+			static REL::Relocation<AnimationObjects**> singleton{ RELOCATION_ID(514179, 400328) };
 			return *singleton;
 		}
 

--- a/include/RE/B/BGSAddToPlayerInventoryEvent.h
+++ b/include/RE/B/BGSAddToPlayerInventoryEvent.h
@@ -23,7 +23,7 @@ namespace RE
 	public:
 		[[nodiscard]] static std::uint32_t& GetIndex()
 		{
-			REL::Relocation<std::uint32_t*> index{ RELOCATION_ID(508412, 380074) };
+			static REL::Relocation<std::uint32_t*> index{ RELOCATION_ID(508412, 380074) };
 			return *index;
 		}
 

--- a/include/RE/B/BGSDecalManager.h
+++ b/include/RE/B/BGSDecalManager.h
@@ -16,7 +16,7 @@ namespace RE
 	public:
 		static BGSDecalManager* GetSingleton()
 		{
-			REL::Relocation<BGSDecalManager**> singleton{ RELOCATION_ID(514414, 400561) };
+			static REL::Relocation<BGSDecalManager**> singleton{ RELOCATION_ID(514414, 400561) };
 			return *singleton;
 		}
 

--- a/include/RE/B/BGSGrassManager.h
+++ b/include/RE/B/BGSGrassManager.h
@@ -14,7 +14,7 @@ namespace RE
 	public:
 		static BGSGrassManager* GetSingleton()
 		{
-			REL::Relocation<BGSGrassManager**> singleton{ RELOCATION_ID(514292, 400452) };
+			static REL::Relocation<BGSGrassManager**> singleton{ RELOCATION_ID(514292, 400452) };
 			return *singleton;
 		}
 

--- a/include/RE/B/BGSImpactManager.h
+++ b/include/RE/B/BGSImpactManager.h
@@ -49,7 +49,7 @@ namespace RE
 
 		static BGSImpactManager* GetSingleton()
 		{
-			REL::Relocation<BGSImpactManager**> singleton{ RELOCATION_ID(515123, 401262) };
+			static REL::Relocation<BGSImpactManager**> singleton{ RELOCATION_ID(515123, 401262) };
 			return *singleton;
 		}
 

--- a/include/RE/B/BGSSaveLoadGame.h
+++ b/include/RE/B/BGSSaveLoadGame.h
@@ -68,7 +68,7 @@ namespace RE
 
 		static BGSSaveLoadGame* GetSingleton()
 		{
-			REL::Relocation<BGSSaveLoadGame**> singleton{ RELOCATION_ID(516851, 403330) };
+			static REL::Relocation<BGSSaveLoadGame**> singleton{ RELOCATION_ID(516851, 403330) };
 			return *singleton;
 		}
 

--- a/include/RE/B/BSFaceGenManager.h
+++ b/include/RE/B/BSFaceGenManager.h
@@ -37,7 +37,7 @@ namespace RE
 	public:
 		[[nodiscard]] static BSFaceGenManager* GetSingleton()
 		{
-			REL::Relocation<BSFaceGenManager**> singleton{ RELOCATION_ID(514182, 400331) };
+			static REL::Relocation<BSFaceGenManager**> singleton{ RELOCATION_ID(514182, 400331) };
 			return *singleton;
 		}
 

--- a/include/RE/B/BSMusicManager.h
+++ b/include/RE/B/BSMusicManager.h
@@ -24,7 +24,7 @@ namespace RE
 
 		[[nodiscard]] static BSMusicManager* GetSingleton()
 		{
-			REL::Relocation<BSMusicManager**> singleton{ RELOCATION_ID(514738, 400896) };
+			static REL::Relocation<BSMusicManager**> singleton{ RELOCATION_ID(514738, 400896) };
 			return *singleton;
 		}
 

--- a/include/RE/B/BSPointerHandleManager.h
+++ b/include/RE/B/BSPointerHandleManager.h
@@ -27,7 +27,7 @@ namespace RE
 
 		[[nodiscard]] static auto GetHandleEntries()
 		{
-			REL::Relocation<Entry(*)[0x100000]> entries{ RELOCATION_ID(514478, 400622) };
+			static REL::Relocation<Entry(*)[0x100000]> entries{ RELOCATION_ID(514478, 400622) };
 			return std::span<Entry, 0x100000>{ *entries };
 		}
 	};

--- a/include/RE/B/BSShaderManager.h
+++ b/include/RE/B/BSShaderManager.h
@@ -29,7 +29,7 @@ namespace RE
 		public:
 			static BSShaderManager::State& GetSingleton()
 			{
-				REL::Relocation<BSShaderManager::State*> singleton{ RELOCATION_ID(513211, 390951) };
+				static REL::Relocation<BSShaderManager::State*> singleton{ RELOCATION_ID(513211, 390951) };
 				return *singleton;
 			}
 

--- a/include/RE/B/BSTimer.h
+++ b/include/RE/B/BSTimer.h
@@ -7,19 +7,19 @@ namespace RE
 	public:
 		[[nodiscard]] static BSTimer* GetSingleton() noexcept
 		{
-			REL::Relocation<BSTimer*> singleton{ RELOCATION_ID(523657, 410196) };
+			static REL::Relocation<BSTimer*> singleton{ RELOCATION_ID(523657, 410196) };
 			return singleton.get();
 		}
 
 		static float QGlobalTimeMultiplier()
 		{
-			REL::Relocation<float*> value{ RELOCATION_ID(511882, 388442) };
+			static REL::Relocation<float*> value{ RELOCATION_ID(511882, 388442) };
 			return *value;
 		}
 
 		static float QGlobalTimeMultiplierTarget()
 		{
-			REL::Relocation<float*> value{ RELOCATION_ID(511883, 388443) };
+			static REL::Relocation<float*> value{ RELOCATION_ID(511883, 388443) };
 			return *value;
 		}
 

--- a/include/RE/B/BSTreeManager.h
+++ b/include/RE/B/BSTreeManager.h
@@ -30,7 +30,7 @@ namespace RE
 
 		static BSTreeManager* GetSingleton()
 		{
-			REL::Relocation<BSTreeManager**> singleton{ RELOCATION_ID(514181, 400330) };
+			static REL::Relocation<BSTreeManager**> singleton{ RELOCATION_ID(514181, 400330) };
 			return *singleton;
 		}
 

--- a/include/RE/B/BSUtilityShader.h
+++ b/include/RE/B/BSUtilityShader.h
@@ -47,7 +47,7 @@ namespace RE
 
 		static BSUtilityShader* GetSingleton()
 		{
-			REL::Relocation<BSUtilityShader**> singleton{ RELOCATION_ID(528354, 415300) };
+			static REL::Relocation<BSUtilityShader**> singleton{ RELOCATION_ID(528354, 415300) };
 			return *singleton;
 		}
 		~BSUtilityShader() override;  // 00

--- a/include/RE/B/bhkCollisionFilter.h
+++ b/include/RE/B/bhkCollisionFilter.h
@@ -14,7 +14,7 @@ namespace RE
 
 		[[nodiscard]] static bhkCollisionFilter* GetSingleton()
 		{
-			REL::Relocation<bhkCollisionFilter**> singleton{ RELOCATION_ID(514415, 400562) };
+			static REL::Relocation<bhkCollisionFilter**> singleton{ RELOCATION_ID(514415, 400562) };
 			return *singleton;
 		}
 

--- a/include/RE/B/bhkTelekinesisListener.h
+++ b/include/RE/B/bhkTelekinesisListener.h
@@ -20,7 +20,7 @@ namespace RE
 
 		static bhkTelekinesisListener* GetSingleton()
 		{
-			REL::Relocation<bhkTelekinesisListener**> singleton{ RELOCATION_ID(515445, 401584) };
+			static REL::Relocation<bhkTelekinesisListener**> singleton{ RELOCATION_ID(515445, 401584) };
 			return *singleton;
 		}
 	};

--- a/include/RE/B/bhkWorld.h
+++ b/include/RE/B/bhkWorld.h
@@ -41,13 +41,13 @@ namespace RE
 
 		static float GetWorldScale()
 		{
-			REL::Relocation<float*> worldScale{ RELOCATION_ID(231896, 188105) };
+			static REL::Relocation<float*> worldScale{ RELOCATION_ID(231896, 188105) };
 			return *worldScale;
 		}
 
 		static float GetWorldScaleInverse()
 		{
-			REL::Relocation<float*> worldScaleInverse{ RELOCATION_ID(230692, 187407) };
+			static REL::Relocation<float*> worldScaleInverse{ RELOCATION_ID(230692, 187407) };
 			return *worldScaleInverse;
 		}
 

--- a/include/RE/C/CombatManager.h
+++ b/include/RE/C/CombatManager.h
@@ -26,7 +26,7 @@ namespace RE
 	public:
 		[[nodiscard]] static CombatManager* GetSingleton()
 		{
-			REL::Relocation<CombatManager**> singleton{ RELOCATION_ID(518706, 405246) };
+			static REL::Relocation<CombatManager**> singleton{ RELOCATION_ID(518706, 405246) };
 			return *singleton;
 		}
 

--- a/include/RE/C/CrosshairPickData.h
+++ b/include/RE/C/CrosshairPickData.h
@@ -14,7 +14,7 @@ namespace RE
 	public:
 		static CrosshairPickData* GetSingleton()
 		{
-			REL::Relocation<CrosshairPickData**> singleton{ RELOCATION_ID(515446, 401585) };
+			static REL::Relocation<CrosshairPickData**> singleton{ RELOCATION_ID(515446, 401585) };
 			return *singleton;
 		}
 

--- a/include/RE/F/FOCollisionListener.h
+++ b/include/RE/F/FOCollisionListener.h
@@ -36,7 +36,7 @@ namespace RE
 
 		static FOCollisionListener* GetSingleton()
 		{
-			REL::Relocation<FOCollisionListener**> singleton{ RELOCATION_ID(514284, 400444) };
+			static REL::Relocation<FOCollisionListener**> singleton{ RELOCATION_ID(514284, 400444) };
 			return *singleton;
 		}
 

--- a/include/RE/F/FORM_ENUM_STRING.h
+++ b/include/RE/F/FORM_ENUM_STRING.h
@@ -9,7 +9,7 @@ namespace RE
 	public:
 		[[nodiscard]] static std::span<FORM_ENUM_STRING, 138> GetFormEnumString()
 		{
-			REL::Relocation<FORM_ENUM_STRING(*)[138]> formEnumString{ RELOCATION_ID(501008, 359120) };
+			static REL::Relocation<FORM_ENUM_STRING(*)[138]> formEnumString{ RELOCATION_ID(501008, 359120) };
 			return { *formEnumString };
 		}
 

--- a/include/RE/G/GarbageCollector.h
+++ b/include/RE/G/GarbageCollector.h
@@ -52,7 +52,7 @@ namespace RE
 
 		static GarbageCollector* GetSingleton()
 		{
-			REL::Relocation<GarbageCollector**> singleton{ RELOCATION_ID(514180, 400329) };
+			static REL::Relocation<GarbageCollector**> singleton{ RELOCATION_ID(514180, 400329) };
 			return *singleton;
 		}
 

--- a/include/RE/H/hkContainerAllocators.h
+++ b/include/RE/H/hkContainerAllocators.h
@@ -24,7 +24,7 @@ namespace RE
 
 		[[nodiscard]] static Allocator* GetSingleton()
 		{
-			REL::Relocation<hkContainerHeapAllocator::Allocator*> singleton{ RELOCATION_ID(510713, 383828) };
+			static REL::Relocation<hkContainerHeapAllocator::Allocator*> singleton{ RELOCATION_ID(510713, 383828) };
 			return singleton.get();
 		}
 	};

--- a/include/RE/I/ImageSpaceManager.h
+++ b/include/RE/I/ImageSpaceManager.h
@@ -179,7 +179,7 @@ namespace RE
 
 		static ImageSpaceManager* GetSingleton()
 		{
-			REL::Relocation<ImageSpaceManager**> singleton{ RELOCATION_ID(527731, 414660) };
+			static REL::Relocation<ImageSpaceManager**> singleton{ RELOCATION_ID(527731, 414660) };
 			return *singleton;
 		}
 

--- a/include/RE/M/MenuTopicManager.h
+++ b/include/RE/M/MenuTopicManager.h
@@ -61,7 +61,7 @@ namespace RE
 
 		static MenuTopicManager* GetSingleton()
 		{
-			REL::Relocation<MenuTopicManager**> singleton{ RELOCATION_ID(514959, 401099) };
+			static REL::Relocation<MenuTopicManager**> singleton{ RELOCATION_ID(514959, 401099) };
 			return *singleton;
 		}
 

--- a/include/RE/M/MistMenu.h
+++ b/include/RE/M/MistMenu.h
@@ -60,7 +60,7 @@ namespace RE
 
 		static MistMenu* GetSingleton()
 		{
-			REL::Relocation<MistMenu**> singleton{ RELOCATION_ID(519827, 406370) };
+			static REL::Relocation<MistMenu**> singleton{ RELOCATION_ID(519827, 406370) };
 			return *singleton;
 		}
 

--- a/include/RE/N/NiRTTI.h
+++ b/include/RE/N/NiRTTI.h
@@ -100,7 +100,7 @@ To netimmerse_cast(const From* a_from)
 		return nullptr;
 	}
 
-	REL::Relocation<const RE::NiRTTI*> to{ RE::Ni_Impl::remove_cvpr_t<To>::Ni_RTTI };
+	static REL::Relocation<const RE::NiRTTI*> to{ RE::Ni_Impl::remove_cvpr_t<To>::Ni_RTTI };
 
 	const RE::NiRTTI* toRTTI = to.get();
 	const RE::NiRTTI* fromRTTI = a_from->GetRTTI();

--- a/include/RE/P/Precipitation.h
+++ b/include/RE/P/Precipitation.h
@@ -35,7 +35,7 @@ namespace RE
 
 		static NiPoint3 GetDirection()
 		{
-			REL::Relocation<NiPoint3*> precipDirection{ RELOCATION_ID(515509, 401648) };
+			static REL::Relocation<NiPoint3*> precipDirection{ RELOCATION_ID(515509, 401648) };
 			return *precipDirection;
 		}
 

--- a/include/RE/R/RenderTargetManager.h
+++ b/include/RE/R/RenderTargetManager.h
@@ -12,7 +12,7 @@ namespace RE
 		public:
 			[[nodiscard]] static RenderTargetManager* GetSingleton()
 			{
-				REL::Relocation<RenderTargetManager**> singleton{ RELOCATION_ID(524970, 411451) };
+				static REL::Relocation<RenderTargetManager**> singleton{ RELOCATION_ID(524970, 411451) };
 				return *singleton;
 			}
 

--- a/include/RE/R/ReticuleController.h
+++ b/include/RE/R/ReticuleController.h
@@ -10,7 +10,7 @@ namespace RE
 	public:
 		static ReticuleController& GetSingleton()
 		{
-			REL::Relocation<ReticuleController*> singleton{ RELOCATION_ID(508607, 380335) };
+			static REL::Relocation<ReticuleController*> singleton{ RELOCATION_ID(508607, 380335) };
 			return *singleton;
 		}
 

--- a/include/RE/RTTI.h
+++ b/include/RE/RTTI.h
@@ -225,8 +225,8 @@ template <
 		int> = 0>
 To skyrim_cast(From* a_from)
 {
-	REL::Relocation<void*> from{ RE::detail::remove_cvpr_t<From>::RTTI };
-	REL::Relocation<void*> to{ RE::detail::remove_cvpr_t<To>::RTTI };
+	static REL::Relocation<void*> from{ RE::detail::remove_cvpr_t<From>::RTTI };
+	static REL::Relocation<void*> to{ RE::detail::remove_cvpr_t<To>::RTTI };
 	return static_cast<To>(
 		RE::RTDynamicCast(
 			const_cast<void*>(

--- a/include/RE/S/ScreenSplatter.h
+++ b/include/RE/S/ScreenSplatter.h
@@ -15,7 +15,7 @@ namespace RE
 	public:
 		static ScreenSplatter* GetSingleton()
 		{
-			REL::Relocation<ScreenSplatter**> singleton{ RELOCATION_ID(514512, 400672) };
+			static REL::Relocation<ScreenSplatter**> singleton{ RELOCATION_ID(514512, 400672) };
 			return *singleton;
 		}
 

--- a/include/RE/S/State.h
+++ b/include/RE/S/State.h
@@ -13,7 +13,7 @@ namespace RE
 		public:
 			[[nodiscard]] static State* GetSingleton()
 			{
-				REL::Relocation<State*> singleton{ RELOCATION_ID(524998, 411479) };
+				static REL::Relocation<State*> singleton{ RELOCATION_ID(524998, 411479) };
 				return singleton.get();
 			}
 

--- a/include/RE/S/SubtitleManager.h
+++ b/include/RE/S/SubtitleManager.h
@@ -23,7 +23,7 @@ namespace RE
 	public:
 		static SubtitleManager* GetSingleton()
 		{
-			REL::Relocation<SubtitleManager**> singleton{ RELOCATION_ID(514283, 400443) };
+			static REL::Relocation<SubtitleManager**> singleton{ RELOCATION_ID(514283, 400443) };
 			return *singleton;
 		}
 

--- a/include/RE/T/TESForm.h
+++ b/include/RE/T/TESForm.h
@@ -193,8 +193,8 @@ namespace RE
 				BSTHashMap<FormID, TESForm*>*,
 				std::reference_wrapper<BSReadWriteLock>>
 		{
-			REL::Relocation<BSTHashMap<FormID, TESForm*>**> allForms{ RELOCATION_ID(514351, 400507) };
-			REL::Relocation<BSReadWriteLock*>               allFormsMapLock{ RELOCATION_ID(514360, 400517) };
+			static REL::Relocation<BSTHashMap<FormID, TESForm*>**> allForms{ RELOCATION_ID(514351, 400507) };
+			static REL::Relocation<BSReadWriteLock*>               allFormsMapLock{ RELOCATION_ID(514360, 400517) };
 			return { *allForms, std::ref(*allFormsMapLock) };
 		}
 
@@ -203,8 +203,8 @@ namespace RE
 				BSTHashMap<BSFixedString, TESForm*>*,
 				std::reference_wrapper<BSReadWriteLock>>
 		{
-			REL::Relocation<BSTHashMap<BSFixedString, TESForm*>**> allFormsByEditorID{ RELOCATION_ID(514352, 400509) };
-			REL::Relocation<BSReadWriteLock*>                      allFormsEditorIDMapLock{ RELOCATION_ID(514361, 400518) };
+			static REL::Relocation<BSTHashMap<BSFixedString, TESForm*>**> allFormsByEditorID{ RELOCATION_ID(514352, 400509) };
+			static REL::Relocation<BSReadWriteLock*>                      allFormsEditorIDMapLock{ RELOCATION_ID(514361, 400518) };
 			return { *allFormsByEditorID, std::ref(*allFormsEditorIDMapLock) };
 		}
 

--- a/include/RE/T/TESWaterSystem.h
+++ b/include/RE/T/TESWaterSystem.h
@@ -28,7 +28,7 @@ namespace RE
 	public:
 		[[nodiscard]] static TESWaterSystem* GetSingleton()
 		{
-			REL::Relocation<TESWaterSystem**> singleton{ RELOCATION_ID(514290, 400450) };
+			static REL::Relocation<TESWaterSystem**> singleton{ RELOCATION_ID(514290, 400450) };
 			return *singleton;
 		}
 

--- a/include/RE/T/TLSData.h
+++ b/include/RE/T/TLSData.h
@@ -25,8 +25,8 @@ namespace RE
 
 	inline static TLSData* GetStaticTLSData()
 	{
-		REL::Relocation<std::uint32_t*> tlsIndex{ Offset::TlsIndex };
-		auto                            tlsDataArray = reinterpret_cast<TLSData**>(__readgsqword(0x58));
+		static REL::Relocation<std::uint32_t*> tlsIndex{ Offset::TlsIndex };
+		auto                                   tlsDataArray = reinterpret_cast<TLSData**>(__readgsqword(0x58));
 		return tlsDataArray[*tlsIndex];
 	}
 }

--- a/include/RE/V/VATS.h
+++ b/include/RE/V/VATS.h
@@ -47,7 +47,7 @@ namespace RE
 
 		[[nodiscard]] static VATS* GetSingleton()
 		{
-			REL::Relocation<VATS**> singleton{ RELOCATION_ID(514725, 400883) };
+			static REL::Relocation<VATS**> singleton{ RELOCATION_ID(514725, 400883) };
 			return *singleton;
 		}
 

--- a/src/RE/A/Actor.cpp
+++ b/src/RE/A/Actor.cpp
@@ -438,7 +438,7 @@ namespace RE
 	FIGHT_REACTION Actor::GetFactionReaction(Actor* a_other) const
 	{
 		using func_t = decltype(&Actor::GetFactionReaction);
-		REL::Relocation<func_t> func{ RELOCATION_ID(36658, 37666) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(36658, 37666) };
 		return func(this, a_other);
 	}
 
@@ -800,7 +800,7 @@ namespace RE
 	bool Actor::IsCombatTarget(Actor* a_other) const
 	{
 		using func_t = decltype(&Actor::IsCombatTarget);
-		REL::Relocation<func_t> func{ RELOCATION_ID(37618, 38571) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(37618, 38571) };
 		return func(this, a_other);
 	}
 

--- a/src/RE/A/ActorEquipManager.cpp
+++ b/src/RE/A/ActorEquipManager.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	ActorEquipManager* ActorEquipManager::GetSingleton()
 	{
-		REL::Relocation<ActorEquipManager**> singleton{ Offset::ActorEquipManager::Singleton };
+		static REL::Relocation<ActorEquipManager**> singleton{ Offset::ActorEquipManager::Singleton };
 		return *singleton;
 	}
 

--- a/src/RE/B/BGSCreatedObjectManager.cpp
+++ b/src/RE/B/BGSCreatedObjectManager.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	BGSCreatedObjectManager* BGSCreatedObjectManager::GetSingleton()
 	{
-		REL::Relocation<BGSCreatedObjectManager**> singleton{ RELOCATION_ID(514172, 400320) };
+		static REL::Relocation<BGSCreatedObjectManager**> singleton{ RELOCATION_ID(514172, 400320) };
 		return *singleton;
 	}
 

--- a/src/RE/B/BGSFootstepManager.cpp
+++ b/src/RE/B/BGSFootstepManager.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	BGSFootstepManager* BGSFootstepManager::GetSingleton()
 	{
-		REL::Relocation<BGSFootstepManager**> singleton{ Offset::BGSFootstepManager::Singleton };
+		static REL::Relocation<BGSFootstepManager**> singleton{ Offset::BGSFootstepManager::Singleton };
 		return *singleton;
 	}
 }

--- a/src/RE/B/BGSSaveLoadManager.cpp
+++ b/src/RE/B/BGSSaveLoadManager.cpp
@@ -4,21 +4,21 @@ namespace RE
 {
 	BGSSaveLoadManager* BGSSaveLoadManager::GetSingleton()
 	{
-		REL::Relocation<BGSSaveLoadManager**> singleton{ Offset::BGSSaveLoadManager::Singleton };
+		static REL::Relocation<BGSSaveLoadManager**> singleton{ Offset::BGSSaveLoadManager::Singleton };
 		return *singleton;
 	}
 
 	bool BGSSaveLoadFileEntry::PopulateFileEntryData()
 	{
 		using func_t = decltype(&BGSSaveLoadFileEntry::PopulateFileEntryData);
-		REL::Relocation<func_t> func{ RELOCATION_ID(34627, 35547) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(34627, 35547) };
 		return func(this);
 	}
 
 	void BGSSaveLoadManager::GenerateCharacterID()
 	{
 		using func_t = decltype(&BGSSaveLoadManager::GenerateCharacterID);
-		REL::Relocation<func_t> func{ RELOCATION_ID(34847, 35757) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(34847, 35757) };
 		return func(this);
 	}
 

--- a/src/RE/B/BGSStoryTeller.cpp
+++ b/src/RE/B/BGSStoryTeller.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	BGSStoryTeller* BGSStoryTeller::GetSingleton()
 	{
-		REL::Relocation<BGSStoryTeller**> singleton{ Offset::BGSStoryTeller::Singleton };
+		static REL::Relocation<BGSStoryTeller**> singleton{ Offset::BGSStoryTeller::Singleton };
 		return *singleton;
 	}
 

--- a/src/RE/B/BSDirectInputManager.cpp
+++ b/src/RE/B/BSDirectInputManager.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	BSDirectInputManager* BSDirectInputManager::GetSingleton()
 	{
-		REL::Relocation<BSDirectInputManager**> singleton{ RELOCATION_ID(517046, 403554) };
+		static REL::Relocation<BSDirectInputManager**> singleton{ RELOCATION_ID(517046, 403554) };
 		return *singleton;
 	}
 

--- a/src/RE/B/BSInputDeviceManager.cpp
+++ b/src/RE/B/BSInputDeviceManager.cpp
@@ -11,7 +11,7 @@ namespace RE
 {
 	BSInputDeviceManager* BSInputDeviceManager::GetSingleton()
 	{
-		REL::Relocation<BSInputDeviceManager**> singleton{ Offset::BSInputDeviceManager::Singleton };
+		static REL::Relocation<BSInputDeviceManager**> singleton{ Offset::BSInputDeviceManager::Singleton };
 		return *singleton;
 	}
 

--- a/src/RE/B/BSInputEventQueue.cpp
+++ b/src/RE/B/BSInputEventQueue.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	BSInputEventQueue* BSInputEventQueue::GetSingleton()
 	{
-		REL::Relocation<BSInputEventQueue**> singleton{ RELOCATION_ID(520856, 407374) };
+		static REL::Relocation<BSInputEventQueue**> singleton{ RELOCATION_ID(520856, 407374) };
 		return *singleton;
 	}
 

--- a/src/RE/B/BSResponse.cpp
+++ b/src/RE/B/BSResponse.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	ResponseDictionary* ResponseDictionary::GetSingleton()
 	{
-		REL::Relocation<ResponseDictionary**> singleton{ RELOCATION_ID(517372, 403902) };
+		static REL::Relocation<ResponseDictionary**> singleton{ RELOCATION_ID(517372, 403902) };
 		return *singleton;
 	}
 }

--- a/src/RE/B/BSScaleformManager.cpp
+++ b/src/RE/B/BSScaleformManager.cpp
@@ -11,7 +11,7 @@ namespace RE
 {
 	BSScaleformManager* BSScaleformManager::GetSingleton()
 	{
-		REL::Relocation<BSScaleformManager**> singleton{ RELOCATION_ID(516573, 402775) };
+		static REL::Relocation<BSScaleformManager**> singleton{ RELOCATION_ID(516573, 402775) };
 		return *singleton;
 	}
 
@@ -195,13 +195,13 @@ namespace RE
 				static_cast<double>(state->screenWidth) /
 				static_cast<double>(state->screenHeight);
 			if (aspectRatio > 4.0 / 3.0) {
-				REL::Relocation<const Setting*> fSafeZoneXWide{ RELOCATION_ID(512509, 389569) };
-				REL::Relocation<const Setting*> fSafeZoneYWide{ RELOCATION_ID(512511, 389572) };
+				static REL::Relocation<const Setting*> fSafeZoneXWide{ RELOCATION_ID(512509, 389569) };
+				static REL::Relocation<const Setting*> fSafeZoneYWide{ RELOCATION_ID(512511, 389572) };
 
 				return std::make_pair(fSafeZoneXWide->GetFloat(), fSafeZoneYWide->GetFloat());
 			} else {
-				REL::Relocation<const Setting*> fSafeZoneX{ RELOCATION_ID(512513, 389575) };
-				REL::Relocation<const Setting*> fSafeZoneY{ RELOCATION_ID(512515, 389578) };
+				static REL::Relocation<const Setting*> fSafeZoneX{ RELOCATION_ID(512513, 389575) };
+				static REL::Relocation<const Setting*> fSafeZoneY{ RELOCATION_ID(512515, 389578) };
 
 				return std::make_pair(fSafeZoneX->GetFloat(), fSafeZoneY->GetFloat());
 			}

--- a/src/RE/B/BarterMenu.cpp
+++ b/src/RE/B/BarterMenu.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	RefHandle BarterMenu::GetTargetRefHandle()
 	{
-		REL::Relocation<RefHandle*> handle{ RELOCATION_ID(519283, 403520) };
+		static REL::Relocation<RefHandle*> handle{ RELOCATION_ID(519283, 403520) };
 		return *handle;
 	}
 }

--- a/src/RE/B/BookMenu.cpp
+++ b/src/RE/B/BookMenu.cpp
@@ -7,13 +7,13 @@ namespace RE
 {
 	TESObjectBOOK* BookMenu::GetTargetForm()
 	{
-		REL::Relocation<TESObjectBOOK**> book{ RELOCATION_ID(519295, 405835) };
+		static REL::Relocation<TESObjectBOOK**> book{ RELOCATION_ID(519295, 405835) };
 		return *book;
 	}
 
 	TESObjectREFR* BookMenu::GetTargetReference()
 	{
-		REL::Relocation<TESObjectREFRPtr*> refptr{ RELOCATION_ID(519300, 405840) };
+		static REL::Relocation<TESObjectREFRPtr*> refptr{ RELOCATION_ID(519300, 405840) };
 		return refptr->get();
 	}
 

--- a/src/RE/C/Calendar.cpp
+++ b/src/RE/C/Calendar.cpp
@@ -8,7 +8,7 @@ namespace RE
 {
 	Calendar* Calendar::GetSingleton()
 	{
-		REL::Relocation<Calendar**> singleton{ Offset::Calendar::Singleton };
+		static REL::Relocation<Calendar**> singleton{ Offset::Calendar::Singleton };
 		return *singleton;
 	}
 
@@ -88,7 +88,7 @@ namespace RE
 
 	float Calendar::GetHoursPerDay()
 	{
-		REL::Relocation<float*> hours{ RELOCATION_ID(241610, 195681) };
+		static REL::Relocation<float*> hours{ RELOCATION_ID(241610, 195681) };
 		return *hours;
 	}
 

--- a/src/RE/C/CommandTable.cpp
+++ b/src/RE/C/CommandTable.cpp
@@ -56,7 +56,7 @@ namespace RE
 
 	SCRIPT_FUNCTION* SCRIPT_FUNCTION::GetFirstScriptCommand()
 	{
-		REL::Relocation<SCRIPT_FUNCTION*> ptr{ Offset::SCRIPT_FUNCTION::FirstScriptCommand };
+		static REL::Relocation<SCRIPT_FUNCTION*> ptr{ Offset::SCRIPT_FUNCTION::FirstScriptCommand };
 		return ptr.get();
 	}
 
@@ -74,7 +74,7 @@ namespace RE
 
 	SCRIPT_FUNCTION* SCRIPT_FUNCTION::GetFirstConsoleCommand()
 	{
-		REL::Relocation<SCRIPT_FUNCTION*> ptr{ Offset::SCRIPT_FUNCTION::FirstConsoleCommand };
+		static REL::Relocation<SCRIPT_FUNCTION*> ptr{ Offset::SCRIPT_FUNCTION::FirstConsoleCommand };
 		return ptr.get();
 	}
 

--- a/src/RE/C/Console.cpp
+++ b/src/RE/C/Console.cpp
@@ -12,7 +12,7 @@ namespace RE
 
 	ObjectRefHandle Console::GetSelectedRefHandle()
 	{
-		REL::Relocation<ObjectRefHandle*> selectedRef{ Offset::Console::SelectedRef };
+		static REL::Relocation<ObjectRefHandle*> selectedRef{ Offset::Console::SelectedRef };
 		return *selectedRef;
 	}
 

--- a/src/RE/C/ConsoleLog.cpp
+++ b/src/RE/C/ConsoleLog.cpp
@@ -5,7 +5,7 @@ namespace RE
 {
 	ConsoleLog* ConsoleLog::GetSingleton()
 	{
-		REL::Relocation<ConsoleLog**> singleton{ Offset::ConsoleLog::Singleton };
+		static REL::Relocation<ConsoleLog**> singleton{ Offset::ConsoleLog::Singleton };
 		return *singleton;
 	}
 

--- a/src/RE/C/ContainerMenu.cpp
+++ b/src/RE/C/ContainerMenu.cpp
@@ -4,13 +4,13 @@ namespace RE
 {
 	ContainerMenu::ContainerMode ContainerMenu::GetContainerMode()
 	{
-		REL::Relocation<ContainerMode*> mode{ RELOCATION_ID(519396, 405937) };
+		static REL::Relocation<ContainerMode*> mode{ RELOCATION_ID(519396, 405937) };
 		return *mode;
 	}
 
 	RefHandle ContainerMenu::GetTargetRefHandle()
 	{
-		REL::Relocation<RefHandle*> handle{ RELOCATION_ID(519421, 405962) };
+		static REL::Relocation<RefHandle*> handle{ RELOCATION_ID(519421, 405962) };
 		return *handle;
 	}
 }

--- a/src/RE/C/ControlMap.cpp
+++ b/src/RE/C/ControlMap.cpp
@@ -6,7 +6,7 @@ namespace RE
 {
 	ControlMap* ControlMap::GetSingleton()
 	{
-		REL::Relocation<ControlMap**> singleton{ Offset::ControlMap::Singleton };
+		static REL::Relocation<ControlMap**> singleton{ Offset::ControlMap::Singleton };
 		return *singleton;
 	}
 

--- a/src/RE/G/GMemory.cpp
+++ b/src/RE/G/GMemory.cpp
@@ -93,7 +93,7 @@ namespace RE
 
 	GMemoryHeap*& GMemory::GetGlobalHeapRef()
 	{
-		REL::Relocation<GMemoryHeap**> globalHeap{ Offset::GMemory::GlobalHeap };
+		static REL::Relocation<GMemoryHeap**> globalHeap{ Offset::GMemory::GlobalHeap };
 		return *globalHeap;
 	}
 }

--- a/src/RE/G/GameSettingCollection.cpp
+++ b/src/RE/G/GameSettingCollection.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	GameSettingCollection* GameSettingCollection::GetSingleton()
 	{
-		REL::Relocation<GameSettingCollection**> singleton{ Offset::GameSettingCollection::Singleton };
+		static REL::Relocation<GameSettingCollection**> singleton{ Offset::GameSettingCollection::Singleton };
 		return *singleton;
 	}
 

--- a/src/RE/G/GiftMenu.cpp
+++ b/src/RE/G/GiftMenu.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	RefHandle GiftMenu::GetTargetRefHandle()
 	{
-		REL::Relocation<RefHandle*> handle{ RELOCATION_ID(519570, 406111) };
+		static REL::Relocation<RefHandle*> handle{ RELOCATION_ID(519570, 406111) };
 		return *handle;
 	}
 }

--- a/src/RE/I/IFormFactory.cpp
+++ b/src/RE/I/IFormFactory.cpp
@@ -9,8 +9,8 @@ namespace RE
 			IFormFactory* data[std::to_underlying(FormType::Max)];
 		};
 
-		REL::Relocation<Factories*> formFactories{ RELOCATION_ID(514355, 400508) };
-		REL::Relocation<bool*>      formFactoriesInitialized{ RELOCATION_ID(514349, 400503) };
+		static REL::Relocation<Factories*> formFactories{ RELOCATION_ID(514355, 400508) };
+		static REL::Relocation<bool*>      formFactoriesInitialized{ RELOCATION_ID(514349, 400503) };
 		return std::make_pair(formFactories->data, *formFactoriesInitialized);
 	}
 

--- a/src/RE/I/IHandlerFunctor.cpp
+++ b/src/RE/I/IHandlerFunctor.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	HandlerDictionary* HandlerDictionary::GetSingleton()
 	{
-		REL::Relocation<HandlerDictionary**> singleton{ RELOCATION_ID(518086, 404607) };
+		static REL::Relocation<HandlerDictionary**> singleton{ RELOCATION_ID(518086, 404607) };
 		return *singleton;
 	}
 }

--- a/src/RE/I/INIPrefSettingCollection.cpp
+++ b/src/RE/I/INIPrefSettingCollection.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	INIPrefSettingCollection* INIPrefSettingCollection::GetSingleton()
 	{
-		REL::Relocation<INIPrefSettingCollection**> singleton{ Offset::INIPrefSettingCollection::Singleton };
+		static REL::Relocation<INIPrefSettingCollection**> singleton{ Offset::INIPrefSettingCollection::Singleton };
 		return *singleton;
 	}
 }

--- a/src/RE/I/INISettingCollection.cpp
+++ b/src/RE/I/INISettingCollection.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	INISettingCollection* INISettingCollection::GetSingleton()
 	{
-		REL::Relocation<INISettingCollection**> singleton{ Offset::INISettingCollection::Singleton };
+		static REL::Relocation<INISettingCollection**> singleton{ Offset::INISettingCollection::Singleton };
 		return *singleton;
 	}
 

--- a/src/RE/I/InterfaceStrings.cpp
+++ b/src/RE/I/InterfaceStrings.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	InterfaceStrings* InterfaceStrings::GetSingleton()
 	{
-		REL::Relocation<InterfaceStrings**> singleton{ Offset::InterfaceStrings::Singleton };
+		static REL::Relocation<InterfaceStrings**> singleton{ Offset::InterfaceStrings::Singleton };
 		return *singleton;
 	}
 }

--- a/src/RE/I/Inventory3DManager.cpp
+++ b/src/RE/I/Inventory3DManager.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	Inventory3DManager* Inventory3DManager::GetSingleton()
 	{
-		REL::Relocation<Inventory3DManager**> singleton{ RELOCATION_ID(517051, 403559) };
+		static REL::Relocation<Inventory3DManager**> singleton{ RELOCATION_ID(517051, 403559) };
 		return *singleton;
 	}
 

--- a/src/RE/L/LockpickingMenu.cpp
+++ b/src/RE/L/LockpickingMenu.cpp
@@ -6,7 +6,7 @@ namespace RE
 {
 	TESObjectREFR* LockpickingMenu::GetTargetReference()
 	{
-		REL::Relocation<TESObjectREFRPtr*> refptr{ RELOCATION_ID(519716, 406271) };
+		static REL::Relocation<TESObjectREFRPtr*> refptr{ RELOCATION_ID(519716, 406271) };
 		return refptr->get();
 	}
 }

--- a/src/RE/M/MagicFavorites.cpp
+++ b/src/RE/M/MagicFavorites.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	MagicFavorites* MagicFavorites::GetSingleton()
 	{
-		REL::Relocation<MagicFavorites**> singleton{ Offset::MagicFavorites::Singleton };
+		static REL::Relocation<MagicFavorites**> singleton{ Offset::MagicFavorites::Singleton };
 		return *singleton;
 	}
 

--- a/src/RE/M/Main.cpp
+++ b/src/RE/M/Main.cpp
@@ -7,7 +7,7 @@ namespace RE
 {
 	Main* Main::GetSingleton()
 	{
-		REL::Relocation<Main**> singleton{ Offset::Main::Singleton };
+		static REL::Relocation<Main**> singleton{ Offset::Main::Singleton };
 		return *singleton;
 	}
 
@@ -20,7 +20,7 @@ namespace RE
 
 	float Main::QFrameAnimTime()
 	{
-		REL::Relocation<float*> data{ RELOCATION_ID(516940, 403447) };
+		static REL::Relocation<float*> data{ RELOCATION_ID(516940, 403447) };
 		return *data;
 	}
 
@@ -33,7 +33,7 @@ namespace RE
 
 	Scenegraph* Main::WorldRootNode()
 	{
-		REL::Relocation<NiPointer<Scenegraph>*> nodePtr{ RELOCATION_ID(517006, 403513) };
+		static REL::Relocation<NiPointer<Scenegraph>*> nodePtr{ RELOCATION_ID(517006, 403513) };
 		return nodePtr->get();
 	}
 

--- a/src/RE/M/MenuControls.cpp
+++ b/src/RE/M/MenuControls.cpp
@@ -15,8 +15,8 @@ namespace RE
 
 	MenuControls* MenuControls::GetSingleton()
 	{
-		REL::Relocation<MenuControls**> singelton{ Offset::MenuControls::Singleton };
-		return *singelton;
+		static REL::Relocation<MenuControls**> singleton{ Offset::MenuControls::Singleton };
+		return *singleton;
 	}
 
 	void MenuControls::AddHandler(MenuEventHandler* a_handler)

--- a/src/RE/M/MenuCursor.cpp
+++ b/src/RE/M/MenuCursor.cpp
@@ -5,7 +5,7 @@ namespace RE
 {
 	MenuCursor* MenuCursor::GetSingleton()
 	{
-		REL::Relocation<MenuCursor**> singleton{ RELOCATION_ID(517043, 403551) };
+		static REL::Relocation<MenuCursor**> singleton{ RELOCATION_ID(517043, 403551) };
 		return *singleton;
 	}
 

--- a/src/RE/M/Misc.cpp
+++ b/src/RE/M/Misc.cpp
@@ -62,7 +62,7 @@ namespace RE
 
 	std::uint32_t GetDurationOfApplicationRunTime()
 	{
-		REL::Relocation<std::uint32_t*> runtime{ RELOCATION_ID(523662, 410201) };
+		static REL::Relocation<std::uint32_t*> runtime{ RELOCATION_ID(523662, 410201) };
 		return *runtime;
 	}
 
@@ -81,7 +81,7 @@ namespace RE
 
 	float GetSecondsSinceLastFrame()
 	{
-		REL::Relocation<float*> seconds{ RELOCATION_ID(523660, 410199) };
+		static REL::Relocation<float*> seconds{ RELOCATION_ID(523660, 410199) };
 		return *seconds;
 	}
 

--- a/src/RE/N/NiMemManager.cpp
+++ b/src/RE/N/NiMemManager.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	NiMemManager* NiMemManager::GetSingleton()
 	{
-		REL::Relocation<NiMemManager**> singleton{ Offset::NiMemManager::Singleton };
+		static REL::Relocation<NiMemManager**> singleton{ Offset::NiMemManager::Singleton };
 		return *singleton;
 	}
 

--- a/src/RE/N/NiObject.cpp
+++ b/src/RE/N/NiObject.cpp
@@ -7,7 +7,7 @@ namespace RE
 {
 	const NiRTTI* NiObject::GetRTTI() const
 	{
-		REL::Relocation<const NiRTTI*> rtti{ NiObject::Ni_RTTI };
+		static REL::Relocation<const NiRTTI*> rtti{ NiObject::Ni_RTTI };
 		return rtti.get();
 	}
 

--- a/src/RE/N/NiTimeController.cpp
+++ b/src/RE/N/NiTimeController.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	const NiRTTI* NiTimeController::GetRTTI() const
 	{
-		REL::Relocation<const NiRTTI*> rtti{ NiTimeController::Ni_RTTI };
+		static REL::Relocation<const NiRTTI*> rtti{ NiTimeController::Ni_RTTI };
 		return rtti.get();
 	}
 

--- a/src/RE/P/PlayerCamera.cpp
+++ b/src/RE/P/PlayerCamera.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	PlayerCamera* PlayerCamera::GetSingleton()
 	{
-		REL::Relocation<PlayerCamera**> singleton{ Offset::PlayerCamera::Singleton };
+		static REL::Relocation<PlayerCamera**> singleton{ Offset::PlayerCamera::Singleton };
 		return *singleton;
 	}
 

--- a/src/RE/P/PlayerCharacter.cpp
+++ b/src/RE/P/PlayerCharacter.cpp
@@ -13,13 +13,13 @@ namespace RE
 
 	PlayerCharacter* PlayerCharacter::GetSingleton()
 	{
-		REL::Relocation<NiPointer<PlayerCharacter>*> singleton{ Offset::PlayerCharacter::Singleton };
+		static REL::Relocation<NiPointer<PlayerCharacter>*> singleton{ Offset::PlayerCharacter::Singleton };
 		return singleton->get();
 	}
 
 	bool PlayerCharacter::IsGodMode()
 	{
-		REL::Relocation<bool*> singleton{ RELOCATION_ID(517711, 404238) };
+		static REL::Relocation<bool*> singleton{ RELOCATION_ID(517711, 404238) };
 		return *singleton;
 	}
 

--- a/src/RE/P/PlayerControls.cpp
+++ b/src/RE/P/PlayerControls.cpp
@@ -12,7 +12,7 @@ namespace RE
 
 	PlayerControls* PlayerControls::GetSingleton()
 	{
-		REL::Relocation<PlayerControls**> singleton{ Offset::PlayerControls::Singleton };
+		static REL::Relocation<PlayerControls**> singleton{ Offset::PlayerControls::Singleton };
 		return *singleton;
 	}
 

--- a/src/RE/P/ProcessLists.cpp
+++ b/src/RE/P/ProcessLists.cpp
@@ -10,7 +10,7 @@ namespace RE
 {
 	ProcessLists* ProcessLists::GetSingleton()
 	{
-		REL::Relocation<ProcessLists**> singleton{ RELOCATION_ID(514167, 400315) };
+		static REL::Relocation<ProcessLists**> singleton{ RELOCATION_ID(514167, 400315) };
 		return *singleton;
 	}
 

--- a/src/RE/P/Projectile.cpp
+++ b/src/RE/P/Projectile.cpp
@@ -8,7 +8,7 @@ namespace RE
 {
 	Projectile::Manager* Projectile::Manager::GetSingleton()
 	{
-		REL::Relocation<Manager**> singleton{ RELOCATION_ID(514313, 400473) };
+		static REL::Relocation<Manager**> singleton{ RELOCATION_ID(514313, 400473) };
 		return *singleton;
 	}
 

--- a/src/RE/R/Renderer.cpp
+++ b/src/RE/R/Renderer.cpp
@@ -8,7 +8,7 @@ namespace RE
 	{
 		Renderer* Renderer::GetSingleton() noexcept
 		{
-			REL::Relocation<Renderer*> singleton{ RELOCATION_ID(524907, 411393) };
+			static REL::Relocation<Renderer*> singleton{ RELOCATION_ID(524907, 411393) };
 			return singleton.get();
 		}
 
@@ -134,7 +134,7 @@ namespace RE
 		[[nodiscard]] RendererData* Renderer::GetRendererData()
 		{
 			// Location is a global pointer to the RendererData in the Renderer singleton
-			REL::Relocation<RendererData**> singleton{ RELOCATION_ID(524728, 411347) };
+			static REL::Relocation<RendererData**> singleton{ RELOCATION_ID(524728, 411347) };
 			return *singleton;
 		}
 
@@ -147,14 +147,14 @@ namespace RE
 		[[nodiscard]] REX::W32::ID3D11Device* Renderer::GetDevice()
 		{
 			// Location is a global pointer to the device in the Renderer Data
-			REL::Relocation<REX::W32::ID3D11Device**> device{ RELOCATION_ID(524729, 411348) };
+			static REL::Relocation<REX::W32::ID3D11Device**> device{ RELOCATION_ID(524729, 411348) };
 			return *device;
 		}
 
 		[[nodiscard]] RendererWindow* Renderer::GetCurrentRenderWindow()
 		{
 			// Location is a global pointer to the current renderWindow (which is not necessarily at index 0 in the renderWindows array)
-			REL::Relocation<RendererWindow**> renderWindow{ RELOCATION_ID(524730, 411349) };
+			static REL::Relocation<RendererWindow**> renderWindow{ RELOCATION_ID(524730, 411349) };
 			return *renderWindow;
 		}
 	}

--- a/src/RE/S/SkyrimVM.cpp
+++ b/src/RE/S/SkyrimVM.cpp
@@ -5,7 +5,7 @@ namespace RE
 {
 	SkyrimVM* SkyrimVM::GetSingleton()
 	{
-		REL::Relocation<SkyrimVM**> singleton{ Offset::SkyrimVM::Singleton };
+		static REL::Relocation<SkyrimVM**> singleton{ Offset::SkyrimVM::Singleton };
 		return *singleton;
 	}
 

--- a/src/RE/T/TES.cpp
+++ b/src/RE/T/TES.cpp
@@ -11,7 +11,7 @@ namespace RE
 {
 	TES* TES::GetSingleton()
 	{
-		REL::Relocation<TES**> singleton{ Offset::TES::Singleton };
+		static REL::Relocation<TES**> singleton{ Offset::TES::Singleton };
 		return *singleton;
 	}
 

--- a/src/RE/T/TESDataHandler.cpp
+++ b/src/RE/T/TESDataHandler.cpp
@@ -7,7 +7,7 @@ namespace RE
 {
 	TESDataHandler* TESDataHandler::GetSingleton()
 	{
-		REL::Relocation<TESDataHandler**> singleton{ Offset::TESDataHandler::Singleton };
+		static REL::Relocation<TESDataHandler**> singleton{ Offset::TESDataHandler::Singleton };
 		return *singleton;
 	}
 

--- a/src/RE/T/TESObjectREFR.cpp
+++ b/src/RE/T/TESObjectREFR.cpp
@@ -207,7 +207,7 @@ namespace RE
 	float TESObjectREFR::GetDistance(TESObjectREFR* a_other, bool a_disabledRefs, bool a_ignoreWorldspace) const
 	{
 		using func_t = decltype(&TESObjectREFR::GetDistance);
-		REL::Relocation<func_t> func{ RELOCATION_ID(19396, 19823) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19396, 19823) };
 		return func(this, a_other, a_disabledRefs, a_ignoreWorldspace);
 	}
 

--- a/src/RE/T/TaskQueueInterface.cpp
+++ b/src/RE/T/TaskQueueInterface.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	TaskQueueInterface* TaskQueueInterface::GetSingleton()
 	{
-		REL::Relocation<TaskQueueInterface**> singleton{ RELOCATION_ID(517228, 403759) };
+		static REL::Relocation<TaskQueueInterface**> singleton{ RELOCATION_ID(517228, 403759) };
 		return *singleton;
 	}
 

--- a/src/RE/U/UI.cpp
+++ b/src/RE/U/UI.cpp
@@ -6,7 +6,7 @@ namespace RE
 {
 	UI* UI::GetSingleton()
 	{
-		REL::Relocation<UI**> singleton{ Offset::UI::Singleton };
+		static REL::Relocation<UI**> singleton{ Offset::UI::Singleton };
 		return *singleton;
 	}
 

--- a/src/RE/U/UI3DSceneManager.cpp
+++ b/src/RE/U/UI3DSceneManager.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	UI3DSceneManager* UI3DSceneManager::GetSingleton()
 	{
-		REL::Relocation<UI3DSceneManager**> singleton{ RELOCATION_ID(517052, 403560) };
+		static REL::Relocation<UI3DSceneManager**> singleton{ RELOCATION_ID(517052, 403560) };
 		return *singleton;
 	}
 

--- a/src/RE/U/UIBlurManager.cpp
+++ b/src/RE/U/UIBlurManager.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	UIBlurManager* UIBlurManager::GetSingleton()
 	{
-		REL::Relocation<UIBlurManager**> singleton{ Offset::UIBlurManager::Singleton };
+		static REL::Relocation<UIBlurManager**> singleton{ Offset::UIBlurManager::Singleton };
 		return *singleton;
 	}
 

--- a/src/RE/U/UIMessageQueue.cpp
+++ b/src/RE/U/UIMessageQueue.cpp
@@ -7,7 +7,7 @@ namespace RE
 {
 	UIMessageQueue* UIMessageQueue::GetSingleton()
 	{
-		REL::Relocation<UIMessageQueue**> singleton{ Offset::UIMessageQueue::Singleton };
+		static REL::Relocation<UIMessageQueue**> singleton{ Offset::UIMessageQueue::Singleton };
 		return *singleton;
 	}
 

--- a/src/RE/U/UserEvents.cpp
+++ b/src/RE/U/UserEvents.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	UserEvents* UserEvents::GetSingleton()
 	{
-		REL::Relocation<UserEvents**> singleton{ Offset::UserEvents::Singleton };
+		static REL::Relocation<UserEvents**> singleton{ Offset::UserEvents::Singleton };
 		return *singleton;
 	}
 }


### PR DESCRIPTION
Missed some relocations from this PR #114

One of the main reason for this change is that we saw slow calls using netimmerse_cast in Community Shaders when doing perf tests.