### PR TITLE
Return null when patching call that was replaced with nop slide

### DIFF
--- a/include/SKSE/Trampoline.h
+++ b/include/SKSE/Trampoline.h
@@ -138,9 +138,10 @@ namespace SKSE
 		template <std::size_t N>
 		[[nodiscard]] std::uintptr_t write_branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_data)
 		{
+			const auto isNop = *reinterpret_cast<std::int8_t*>(a_src) == 0x90;
 			const auto disp = reinterpret_cast<std::int32_t*>(a_src + N - 4);
 			const auto nextOp = a_src + N;
-			const auto func = nextOp + *disp;
+			const auto func = isNop ? 0 : nextOp + *disp;
 
 			if constexpr (N == 5) {
 				write_5branch(a_src, a_dst, a_data);


### PR DESCRIPTION
Some mods overwrite unwanted calls with nop slides rather than redirecting it to an empty function. These cases currently need to be [detected manually](https://github.com/AtomCrafty/QuickLootIE/blob/962ec9a9581ddbb312bbf81932539f23e9a362bb/src/Behaviors/LockpickActivation.cpp#L45-L51) every time `write_call` is used.
It would be a bit more comfortable to use (and more obvious when debugging) if `write_call` instead returned a null value when it encounters a nop opcode.

This implementation is pretty basic and only detects simple nop slides, no [multi-byte nops](https://github.com/powerof3/CommonLibSSE/blob/dev/include/REL/Relocation.h#L159-L167) or other irregularities.