### PR TITLE
fix TESQuestTarget struct def

### DIFF
--- a/include/RE/T/TESQuest.h
+++ b/include/RE/T/TESQuest.h
@@ -18,6 +18,7 @@ namespace RE
 {
 	class BGSBaseAlias;
 	class QueuedPromoteQuestTask;
+	class BSTempEffect;
 
 	enum class QuestFlag
 	{
@@ -150,12 +151,14 @@ namespace RE
 		// members
 		std::uint64_t unk00;       // 00
 		TESCondition  conditions;  // 08
-		std::uint8_t  alias;       // 10
-		std::uint8_t  unk11;       // 11
-		std::uint16_t unk12;       // 12
-		std::uint32_t unk14;       // 14
+		std::uint32_t alias;       // 10
+		std::uint32_t unk14;       // 14 - padding?
+		// These two fields might be a structure of some sort - in ae, the function
+		// w/ id 30980 frees both of these fields, taking a pointer to the first.
+		BSTArray<BSTempEffect*> unk18;  // 18
+		BSTArray<BSTempEffect*> unk30;  // 30
 	};
-	static_assert(sizeof(TESQuestTarget) == 0x18);
+	static_assert(sizeof(TESQuestTarget) == 0x48);
 
 	class BGSQuestObjective
 	{


### PR DESCRIPTION
As pr title said; the existing definition for `TESQuestTarget` was missing a couple fields & alias was set to a u8 instead of a u32.

I don't have an effective way to build this normally (i cross-compile from linux and link via rust and don't currently have a way setup to build without rust or linux).  It compiles fine for me but might be worth trying to compile (though I don't see how this would fail, i figured I'd note it anyways). 


I also haven't confirmed this matches w/ SE - if someone can check that for me it'd be appreciated. Calling function id of the cleanup of these two fields (in ae) is `40517`. this seems to be in the code path for pathing / should see `BSPathingLockData`.