### PR TITLE
Fix fmt::format errors, add ActorValueToString

### DIFF
--- a/include/RE/A/ActorValueList.h
+++ b/include/RE/A/ActorValueList.h
@@ -37,7 +37,7 @@ namespace fmt
 		}
 
 		template <class FormatContext>
-		auto format(const RE::ActorValue& a_actorValue, FormatContext& a_ctx)
+		auto format(const RE::ActorValue& a_actorValue, FormatContext& a_ctx) const
 		{
 			auto* info = RE::ActorValueList::GetSingleton()->GetActorValue(a_actorValue);
 			return fmt::format_to(a_ctx.out(), "{}", info ? info->enumName : "None");

--- a/include/RE/A/ActorValueList.h
+++ b/include/RE/A/ActorValueList.h
@@ -22,6 +22,8 @@ namespace RE
 		std::uint32_t   pad04;                                                // 04
 		ActorValueInfo* actorValues[std::to_underlying(ActorValue::kTotal)];  // 08
 	};
+
+	[[nodiscard]] std::string_view ActorValueToString(ActorValue a_actorValue) noexcept;
 }
 
 #ifdef FMT_VERSION
@@ -39,8 +41,7 @@ namespace fmt
 		template <class FormatContext>
 		auto format(const RE::ActorValue& a_actorValue, FormatContext& a_ctx) const
 		{
-			auto* info = RE::ActorValueList::GetSingleton()->GetActorValue(a_actorValue);
-			return fmt::format_to(a_ctx.out(), "{}", info ? info->enumName : "None");
+			return fmt::format_to(a_ctx.out(), "{}", ActorValueToString(a_actorValue));
 		}
 	};
 }
@@ -55,8 +56,7 @@ namespace std
 		template <class FormatContext>
 		auto format(RE::ActorValue a_actorValue, FormatContext& a_ctx)
 		{
-			auto* info = RE::ActorValueList::GetSingleton()->GetActorValue(a_actorValue);
-			return formatter<std::string_view, CharT>::format(info ? info->enumName : "None", a_ctx);
+			return fmt::format_to(a_ctx.out(), "{}", ActorValueToString(a_actorValue));
 		}
 	};
 }

--- a/include/RE/E/EffectArchetypes.h
+++ b/include/RE/E/EffectArchetypes.h
@@ -82,7 +82,7 @@ namespace fmt
 		}
 
 		template <class FormatContext>
-		auto format(const RE::EffectArchetype& a_archetype, FormatContext& a_ctx)
+		auto format(const RE::EffectArchetype& a_archetype, FormatContext& a_ctx) const
 		{
 			return fmt::format_to(a_ctx.out(), "{}", RE::EffectArchetypeToString(a_archetype));
 		}

--- a/include/RE/M/MaterialIDs.h
+++ b/include/RE/M/MaterialIDs.h
@@ -119,7 +119,7 @@ namespace fmt
 		}
 
 		template <class FormatContext>
-		auto format(const RE::MATERIAL_ID& a_materialID, FormatContext& a_ctx)
+		auto format(const RE::MATERIAL_ID& a_materialID, FormatContext& a_ctx) const
 		{
 			return fmt::format_to(a_ctx.out(), "{}", RE::MaterialIDToString(a_materialID));
 		}

--- a/src/RE/A/ActorValueList.cpp
+++ b/src/RE/A/ActorValueList.cpp
@@ -21,4 +21,10 @@ namespace RE
 		}
 		return ActorValue::kNone;
 	}
+
+	std::string_view ActorValueToString(ActorValue a_actorValue) noexcept
+	{
+		auto info = RE::ActorValueList::GetSingleton()->GetActorValue(a_actorValue);
+		return info ? info->enumName : "None";
+	}
 }


### PR DESCRIPTION
Fixed compilation errors for current `spdlog` version (`fmt` only). Add ActorValueToString function for consistency with FormTypeToString, MaterialIDToString and EffectArchetypeToString.