### PR TITLE
Refactor ActorValueList methods

### DIFF
--- a/include/RE/A/ActorValueList.h
+++ b/include/RE/A/ActorValueList.h
@@ -14,9 +14,9 @@ namespace RE
 			return *singleton;
 		}
 
-		[[nodiscard]] ActorValueInfo* GetActorValueInfo(ActorValue a_actorValue) const;
-		[[nodiscard]] ActorValue      LookupActorValueByName(const char* a_enumName) const;
-		[[nodiscard]] const char*     GetActorValueName(ActorValue a_actorValue) const;
+		[[nodiscard]] static ActorValueInfo* GetActorValueInfo(ActorValue a_actorValue);
+		[[nodiscard]] static ActorValue      LookupActorValueByName(const char* a_enumName);
+		[[nodiscard]] static const char*     GetActorValueName(ActorValue a_actorValue);
 
 		// members
 		std::uint32_t   unk00;                                                // 00

--- a/src/RE/A/ActorValueList.cpp
+++ b/src/RE/A/ActorValueList.cpp
@@ -1,32 +1,31 @@
 #include "RE/A/ActorValueList.h"
 
-#include "RE/A/ActorValueInfo.h"
-
 namespace RE
 {
-	ActorValueInfo* ActorValueList::GetActorValueInfo(ActorValue a_actorValue) const
+	ActorValueInfo* ActorValueList::GetActorValueInfo(ActorValue a_actorValue)
 	{
 		using func_t = decltype(&ActorValueList::GetActorValueInfo);
 		static REL::Relocation<func_t> func{ RELOCATION_ID(26569, 27202) };
-		return func(this, a_actorValue);
+		return func(a_actorValue);
 	}
 
-	ActorValue ActorValueList::LookupActorValueByName(const char* a_enumName) const
+	ActorValue ActorValueList::LookupActorValueByName(const char* a_enumName)
 	{
 		using func_t = decltype(&ActorValueList::LookupActorValueByName);
 		static REL::Relocation<func_t> func{ RELOCATION_ID(26570, 27203) };
-		return func(this, a_enumName);
+		return func(a_enumName);
 	}
 
-	const char* ActorValueList::GetActorValueName(ActorValue a_actorValue) const
+	const char* ActorValueList::GetActorValueName(ActorValue a_actorValue)
 	{
 		using func_t = decltype(&ActorValueList::GetActorValueName);
 		static REL::Relocation<func_t> func{ RELOCATION_ID(26561, 27192) };
-		return func(this, a_actorValue);
+		return func(a_actorValue);
 	}
 
 	std::string_view ActorValueToString(ActorValue a_actorValue) noexcept
 	{
-		return ActorValueList::GetSingleton()->GetActorValueName(a_actorValue);
+		auto name = ActorValueList::GetActorValueName(a_actorValue);
+		return name ? name : "None"sv;
 	}
 }

--- a/src/RE/A/ActorValueOwner.cpp
+++ b/src/RE/A/ActorValueOwner.cpp
@@ -19,17 +19,17 @@ namespace RE
 
 	void ActorValueOwner::DamageActorValue(ActorValue a_akValue, float a_value)
 	{
-		auto avi = ActorValueList::GetSingleton()->GetActorValueInfo(a_akValue);
+		auto avi = ActorValueList::GetActorValueInfo(a_akValue);
 
-		float damage = avi->IsInverted() ? std::abs(a_value) : -std::abs(a_value);
+		float damage = avi && avi->IsInverted() ? std::abs(a_value) : -std::abs(a_value);
 		ModActorValue(ACTOR_VALUE_MODIFIER::kDamage, a_akValue, damage);
 	}
 
 	void ActorValueOwner::RestoreActorValue(ActorValue a_akValue, float a_value)
 	{
-		auto avi = ActorValueList::GetSingleton()->GetActorValueInfo(a_akValue);
+		auto avi = ActorValueList::GetActorValueInfo(a_akValue);
 
-		float damage = avi->IsInverted() ? -std::abs(a_value) : std::abs(a_value);
+		float damage = avi && avi->IsInverted() ? -std::abs(a_value) : std::abs(a_value);
 		ModActorValue(ACTOR_VALUE_MODIFIER::kDamage, a_akValue, damage);
 	}
 }


### PR DESCRIPTION
Changed GetActorValueInfo, LookupActorValueByName, and GetActorValueName in ActorValueList to static methods. Added null check when accessing ActorValueInfo in Damage/Restore variants and another null check in ActorValueToString.