### PR TITLE
fix generic param in REL::Relocation::write

### DIFF
--- a/include/REL/Relocation.h
+++ b/include/REL/Relocation.h
@@ -320,7 +320,7 @@ namespace REL
 		void write(const U& a_data)
 			requires(std::same_as<value_type, std::uintptr_t>)
 		{
-			safe_write(address(), std::addressof(a_data), sizeof(T));
+			safe_write(address(), std::addressof(a_data), sizeof(U));
 		}
 
 		template <class U>


### PR DESCRIPTION
```cpp
REL::Relocation baseEnd{ REL::ID(68109), 0x2F };
baseEnd.write<std::uint8_t>(std::uint8_t{ 0x74 });
```

This writes 8 bytes (0x74 then 7 bytes of garbage) since the write call uses sizeof(T) (uintptr_t) instead of sizeof(U) (the argument size).

Unless this is intentionally only supposed to allow you to write the size of the relocation target, but the write (span) one suggests otherwise.