### PR TITLE
Fix `BSTPointerAndFlags` and `GHashSetBase`

### DIFF
--- a/include/RE/B/BSTPointerAndFlags.h
+++ b/include/RE/B/BSTPointerAndFlags.h
@@ -44,7 +44,7 @@ namespace RE
 				clear_flags();
 				a_rhs.clear_flags();
 				_storage.address = a_rhs._storage.address;
-				a_rhs.storage.address = 0;
+				a_rhs._storage.address = 0;
 			}
 			return *this;
 		}

--- a/include/RE/G/GHashSetBase.h
+++ b/include/RE/G/GHashSetBase.h
@@ -211,7 +211,7 @@ namespace RE
 			Clear();
 			if (a_src.IsEmpty() == false) {
 				SetCapacity(a_memAddr, a_src.GetSize());
-				for (const_iterator it = a_src.Begin(); it != a_src.End(); ++it) {
+				for (const_iterator it = a_src.begin(); it != a_src.end(); ++it) {
 					Add(a_memAddr, *it);
 				}
 			}


### PR DESCRIPTION
These reference some methods with the wrong capitalization / without and `_`.  Somehow this was compiling before.