### PR TITLE
Revert "fix: fix entrypoint offsets"

### DIFF
--- a/include/RE/B/BGSEntryPoint.h
+++ b/include/RE/B/BGSEntryPoint.h
@@ -143,7 +143,7 @@ namespace RE
 		static EntryPoint* GetEntryPoint(ENTRY_POINT a_entryPoint)
 		{
 			if (a_entryPoint < ENTRY_POINT::kTotal) {
-				static REL::Relocation<EntryPoint*> entryPoints{ RELOCATION_ID(368994, 675707) };
+				static REL::Relocation<EntryPoint*> entryPoints{ RELOCATION_ID(675707, 368994) };
 				return &entryPoints.get()[a_entryPoint];
 			}
 

--- a/include/RE/B/BGSEntryPointFunction.h
+++ b/include/RE/B/BGSEntryPointFunction.h
@@ -65,7 +65,7 @@ namespace RE
 		static std::uint32_t GetArgumentCount(ENTRY_POINT_FUNCTION_TYPE a_entryPointFunctionType)
 		{
 			if (a_entryPointFunctionType < ENTRY_POINT_FUNCTION_TYPE::kTotal) {
-				static REL::Relocation<std::uint32_t*> entryPointFunctionTypeArgumentCount{ RELOCATION_ID(369210, 502187) };
+				static REL::Relocation<std::uint32_t*> entryPointFunctionTypeArgumentCount{ RELOCATION_ID(502187, 369210) };
 				return entryPointFunctionTypeArgumentCount.get()[a_entryPointFunctionType];
 			}
 
@@ -75,7 +75,7 @@ namespace RE
 		static EntryPointFunction* GetEntryPointFunction(ENTRY_POINT_FUNCTION a_entryPointFunction)
 		{
 			if (a_entryPointFunction < ENTRY_POINT_FUNCTION::kTotal) {
-				static REL::Relocation<EntryPointFunction*> entryPointFunctions{ RELOCATION_ID(369178, 675799) };
+				static REL::Relocation<EntryPointFunction*> entryPointFunctions{ RELOCATION_ID(675799, 369178) };
 				return &entryPointFunctions.get()[a_entryPointFunction];
 			}
 


### PR DESCRIPTION
This reverts commit 6c74e183733c65e229678448de75ecbbe10b2508.

I looked at the wrong ids, apparently it was correct at the start.