### PR TITLE
fix build for linux / clang

### DIFF
--- a/include/RE/B/BSScriptObjectBindPolicy.h
+++ b/include/RE/B/BSScriptObjectBindPolicy.h
@@ -4,6 +4,7 @@
 #include "RE/B/BSFixedString.h"
 #include "RE/B/BSTHashMap.h"
 #include "RE/B/BSTSmartPointer.h"
+#include "RE/V/Variable.h"
 
 namespace RE
 {
@@ -11,7 +12,6 @@ namespace RE
 	{
 		class IVirtualMachine;
 		class Object;
-		class Variable;
 		struct IVMObjectBindInterface;
 
 		class ObjectBindPolicy

--- a/include/RE/H/hkpConvexVerticesShape.h
+++ b/include/RE/H/hkpConvexVerticesShape.h
@@ -2,7 +2,7 @@
 
 #include "RE/H/hkpConvexShape.h"
 
-#include "RE/h/hkArray.h"
+#include "RE/H/hkArray.h"
 
 namespace RE
 {


### PR DESCRIPTION
Fixed a bug causing compile to fail on case sensitive file systems (e.g. on linux or any fs other than ntfs)
Not sure why my build chain is evaluating this but also fixed a bug where a missing stub was causing it to fail to compile.