### PR TITLE
feat: RE NiPick more

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -2123,6 +2123,7 @@ set(SOURCES
 	src/RE/N/NiNode.cpp
 	src/RE/N/NiObject.cpp
 	src/RE/N/NiObjectNET.cpp
+	src/RE/N/NiPick.cpp
 	src/RE/N/NiPoint2.cpp
 	src/RE/N/NiPoint3.cpp
 	src/RE/N/NiQuaternion.cpp

--- a/include/RE/N/NiPick.h
+++ b/include/RE/N/NiPick.h
@@ -65,22 +65,32 @@ namespace RE
 
 		bool PickObjects(const NiPoint3& a_origin, const NiPoint3& a_direction, bool a_append = false);
 
+		class Results : public NiTScrapArray<Record*>
+		{
+		public:
+			virtual ~Results();  // 00
+			// members
+			std::uint32_t resultsCount;  // 18
+			std::uint32_t pad1C;         // 1C
+		};
+		static_assert(sizeof(Results) == 0x20);
+
 		// members
 		REX::EnumSet<PickType, std::uint32_t>       pickType;            // 00
 		REX::EnumSet<SortType, std::uint32_t>       sortType;            // 04
 		REX::EnumSet<IntersectType, std::uint32_t>  intersectType;       // 08
 		REX::EnumSet<CoordinateType, std::uint32_t> coordinateType;      // 0C
-		bool                                        frontOnly;           // 10
-		bool                                        observeAppCullFlag;  // 11
-		bool                                        returnNormal;        // 12
-		bool                                        returnSmoothNormal;  // 13
-		bool                                        returnTexture;       // 14
-		bool                                        returnColor;         // 15
+		bool                                        frontOnly;           // 10 - If true, the triangle logic performs a dot product between the triangle's normal and the ray's direction. If the triangle is facing away from the ray, it discards the hit
+		bool                                        observeAppCullFlag;  // 11 - If true, the raycast will ignore objects that are marked as invisible/hidden
+		bool                                        returnNormal;        // 12 - If true, it calculates the crossproduct of the triangle's edges and writes it to Record::normal. If false, it leaves the normal field as 0
+		bool                                        returnSmoothNormal;  // 13 - If true, instead of just using the flat triangle normal, it looks at the 3 vertices of the triangle, reads their individual normals, and interpolates them using barycentric coordinates to give a smooth, rounded normal for the hit location
+		bool                                        returnTexture;       // 14 - Dead code, not used it appears
+		bool                                        returnColor;         // 15 - Dead code, not used it appears
 		std::uint16_t                               pad16;               // 16
-		NiPointer<NiAVObject>                       root;                // 18
-		NiTScrapArray<Record*>                      pickResults;         // 20
-		NiPoint3                                    origin;              // 38
-		NiPoint3                                    direction;           // 44
+		NiPointer<NiAVObject>                       root;                // 18 - What the raycast is performed against
+		Results                                     pickResults;         // 20
+		NiPoint3                                    origin;              // 40 - Dead code, not used it appears
+		std::uint32_t                               pad4C;               // 4C
 
 	private:
 		NiPick() = delete;

--- a/include/RE/N/NiPick.h
+++ b/include/RE/N/NiPick.h
@@ -3,6 +3,7 @@
 #include "RE/N/NiPoint3.h"
 #include "RE/N/NiSmartPointer.h"
 #include "RE/N/NiTArray.h"
+#include "RE/N/NiTCollection.h"
 
 namespace RE
 {
@@ -14,6 +15,7 @@ namespace RE
 		class Record
 		{
 		public:
+			// members
 			NiPointer<NiAVObject> object;     // 00
 			NiPoint3              intersect;  // 08
 			NiPoint3              normal;     // 14
@@ -22,44 +24,70 @@ namespace RE
 		};
 		static_assert(sizeof(Record) == 0x28);
 
-		enum class PickType
+		enum class PickType : std::uint32_t
 		{
 			FIND_ALL = 0,
-			FIND_FIRST = 1,
+			FIND_FIRST = 1
 		};
 
-		enum class SortType
+		enum class SortType : std::uint32_t
 		{
 			SORT = 0,
-			NO_SORT = 1,
+			NO_SORT = 1
 		};
 
-		enum class IntersectType
+		enum class IntersectType : std::uint32_t
 		{
 			BOUND_INTERSECT = 0,
-			TRIANGLE_INTERSECT = 1,
+			TRIANGLE_INTERSECT = 1
 		};
 
-		enum class CoordinateType
+		enum class CoordinateType : std::uint32_t
 		{
 			MODEL_COORDINATES = 0,
-			WORLD_COORDINATES = 1,
+			WORLD_COORDINATES = 1
 		};
 
+		struct Deleter
+		{
+			void operator()(NiPick* a_pick) const
+			{
+				if (a_pick) {
+					a_pick->Destroy();
+				}
+			}
+		};
+
+		using Ptr = std::unique_ptr<NiPick, Deleter>;
+
+		[[nodiscard]] static Ptr Create(std::uint32_t a_initialSize = 0, std::uint32_t a_growBy = 1);
+		void                     Destroy();
+
+		bool PickObjects(const NiPoint3& a_origin, const NiPoint3& a_direction, bool a_append = false);
+
+		// members
 		REX::EnumSet<PickType, std::uint32_t>       pickType;            // 00
 		REX::EnumSet<SortType, std::uint32_t>       sortType;            // 04
 		REX::EnumSet<IntersectType, std::uint32_t>  intersectType;       // 08
 		REX::EnumSet<CoordinateType, std::uint32_t> coordinateType;      // 0C
 		bool                                        frontOnly;           // 10
 		bool                                        observeAppCullFlag;  // 11
-		std::uint8_t                                pad12[6];            // 12
+		bool                                        returnNormal;        // 12
+		bool                                        returnSmoothNormal;  // 13
+		bool                                        returnTexture;       // 14
+		bool                                        returnColor;         // 15
+		std::uint16_t                               pad16;               // 16
 		NiPointer<NiAVObject>                       root;                // 18
 		NiTScrapArray<Record*>                      pickResults;         // 20
-		std::uint64_t                               unk38;               // 38
-		std::uint64_t                               unk40;               // 40
-		std::uint8_t                                unk48;               // 48
-		bool                                        returnNormal;        // 49
-		std::uint8_t                                pad4A[6];            // 4A
+		NiPoint3                                    origin;              // 38
+		NiPoint3                                    direction;           // 44
+
+	private:
+		NiPick() = delete;
+		~NiPick() = delete;
+
+		NiPick* ctor(std::uint32_t a_initialSize, std::uint32_t a_growBy);
+		void    dtor();
 	};
-	static_assert(sizeof(NiPick) == 0x50);  // It isn't clear whether this is the actual size
+	static_assert(sizeof(NiPick) == 0x50);
 }

--- a/src/RE/N/NiPick.cpp
+++ b/src/RE/N/NiPick.cpp
@@ -1,0 +1,41 @@
+#include "RE/N/NiPick.h"
+#include "RE/N/NiAVObject.h"
+
+namespace RE
+{
+	NiPick::Ptr NiPick::Create(std::uint32_t a_initialSize, std::uint32_t a_growBy)
+	{
+		auto* pick = NiAlloc<NiPick>(1);
+		if (pick) {
+			pick->ctor(a_initialSize, a_growBy);
+		}
+		return Ptr(pick);
+	}
+
+	void NiPick::Destroy()
+	{
+		dtor();
+		NiFree(this);
+	}
+
+	NiPick* NiPick::ctor(std::uint32_t a_initialSize, std::uint32_t a_growBy)
+	{
+		using func_t = decltype(&NiPick::ctor);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(70361, 71857) };  //Vr: 0xCD8370
+		return func(this, a_initialSize, a_growBy);
+	}
+
+	void NiPick::dtor()
+	{
+		using func_t = decltype(&NiPick::dtor);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(70362, 71858) };  //Vr: 0xCD8430
+		return func(this);
+	}
+
+	bool NiPick::PickObjects(const NiPoint3& a_origin, const NiPoint3& a_direction, bool a_append)
+	{
+		using func_t = decltype(&NiPick::PickObjects);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(70363, 71859) };  //Vr: 0xCD8480
+		return func(this, a_origin, a_direction, a_append);
+	}
+}


### PR DESCRIPTION
Expands on NiPick a bit. This will allow people to use it for extremely useful/precise raycasting.

NiPick can't use normal C++ new/delete because it contains an NiTScrapArray member that has a vtable and does its own allocations during construction. If we let C++ construct it first and then call the game's ctor, the game overwrites the vtable and buffer pointer without freeing what C++ already set up, leaking memory. 

Same problem in reverse on destruction. the game's dtor does its own cleanup on the array and the root NiPointer, so running C++ destructors on top of that would double-free. 

We sidestep all of this by raw-allocating with NiAlloc, calling the game's ctor/dtor directly, and wrapping it in a unique_ptr with a custom deleter for RAII/use-simplicity..