### PR TITLE
Fix for PlayImpactEffect function passing wrong string type

### DIFF
--- a/include/RE/B/BGSImpactManager.h
+++ b/include/RE/B/BGSImpactManager.h
@@ -71,7 +71,7 @@ namespace RE
 			return *singleton;
 		}
 
-		bool PlayImpactEffect(TESObjectREFR* a_ref, BGSImpactDataSet* a_impactEffect, const BSFixedString& a_nodeName, NiPoint3& a_pickDirection, float a_pickLength, bool a_applyNodeRotation, bool a_useNodeLocalRotation)
+		bool PlayImpactEffect(TESObjectREFR* a_ref, BGSImpactDataSet* a_impactEffect, const char* a_nodeName, NiPoint3& a_pickDirection, float a_pickLength, bool a_applyNodeRotation, bool a_useNodeLocalRotation)
 		{
 			using func_t = decltype(&BGSImpactManager::PlayImpactEffect);
 			static REL::Relocation<func_t> func{ RELOCATION_ID(35320, 36215) };


### PR DESCRIPTION
Fix for PlayImpactEffect function, which passed the wrong string type for bone name, causing it to always silently fail and place impact at actor root.

- BUG: `const BSFixedString&`
- FIXED: `const char*`

When passing a string in, make sure it's a C-string `c_str()`