### PR TITLE
Unveiled 2 additional fields in BGSScene

### DIFF
--- a/include/RE/B/BGSScene.h
+++ b/include/RE/B/BGSScene.h
@@ -99,9 +99,9 @@ namespace RE
 		std::uint8_t                                            unkB1;                  // B1
 		std::uint8_t                                            unkB2;                  // B2
 		std::uint8_t                                            unkB3;                  // B3
-		std::uint32_t                                           unkB4;                  // B4
+		std::uint32_t                                           isShuttingDown;         // 1 if scene is actually shutting down
 		std::uint32_t                                           unkB8;                  // B8
-		std::uint32_t                                           unkBC;                  // BC
+		std::uint32_t                                           currentPhaseIndex;      // -1 if scene is not playing, starting with 1
 		std::uint32_t                                           unkC0;                  // C0
 		std::uint32_t                                           padC4;                  // C4
 	};


### PR DESCRIPTION
During Scene debugging I was able to identify two unknown fields:

- One flag signals if a scene is actually shutting down
- One value contains the active scene phase index