### PR TITLE
BGSCreatedObjectManager::AddPotion

### DIFF
--- a/include/RE/B/BGSCreatedObjectManager.h
+++ b/include/RE/B/BGSCreatedObjectManager.h
@@ -9,6 +9,7 @@
 namespace RE
 {
 	class MagicItem;
+	class AlchemyItem;
 	class EnchantmentItem;
 
 	class BGSCreatedObjectManager : public BSTSingletonSDM<BGSCreatedObjectManager>
@@ -27,6 +28,7 @@ namespace RE
 		EnchantmentItem* AddArmorEnchantment(BSTArray<Effect>& a_effects);
 		EnchantmentItem* AddWeaponEnchantment(BSTArray<Effect>& a_effects);
 		void             DestroyEnchantment(EnchantmentItem* a_enchantment, bool a_isWeapon);
+		void             AddPotion(AlchemyItem*& a_created, const BSTArray<Effect>& a_effects);
 
 		// members
 		std::uint8_t                                    pad01;               // 01

--- a/include/RE/B/BGSCreatedObjectManager.h
+++ b/include/RE/B/BGSCreatedObjectManager.h
@@ -58,7 +58,6 @@ namespace RE
 		EnchantmentItem* AddWeaponEnchantment(BSTArray<Effect>& a_effects);
 		void             AddPotion(BSTSmartPointer<AlchemyItem, BSTCreatedObjectSmartPointerPolicy>& a_created, BSTArray<Effect>& a_effects);
 		void             DestroyEnchantment(EnchantmentItem* a_enchantment, bool a_isWeapon);
-		void             AddPotion(AlchemyItem*& a_created, const BSTArray<Effect>& a_effects);
 
 		// members
 		std::uint8_t                                    pad01;               // 01

--- a/include/RE/B/BGSCreatedObjectManager.h
+++ b/include/RE/B/BGSCreatedObjectManager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "RE/A/AlchemyItem.h"
 #include "RE/B/BSAtomic.h"
 #include "RE/B/BSTArray.h"
 #include "RE/B/BSTHashMap.h"
@@ -15,6 +16,34 @@ namespace RE
 	class BGSCreatedObjectManager : public BSTSingletonSDM<BGSCreatedObjectManager>
 	{
 	public:
+		void DecrementRef(AlchemyItem* a_alchItem);
+		void IncrementRef(AlchemyItem* a_alchItem);
+
+		template <class T>
+		struct BSTCreatedObjectSmartPointerPolicy
+		{
+		public:
+			static void Acquire(stl::not_null<T*> a_ptr)
+			{
+				const auto manager = BGSCreatedObjectManager::GetSingleton();
+				if (manager &&
+					a_ptr->IsDynamicForm() &&
+					a_ptr->Is(FormType::AlchemyItem)) {
+					manager->IncrementRef(static_cast<AlchemyItem*>(a_ptr));
+				}
+			}
+
+			static void Release(stl::not_null<T*> a_ptr)
+			{
+				const auto manager = BGSCreatedObjectManager::GetSingleton();
+				if (manager &&
+					a_ptr->IsDynamicForm() &&
+					a_ptr->Is(FormType::AlchemyItem)) {
+					manager->DecrementRef(static_cast<AlchemyItem*>(a_ptr));
+				}
+			}
+		};
+
 		struct CreatedMagicItemData
 		{
 			MagicItem*             magicItem;  // 00
@@ -27,6 +56,7 @@ namespace RE
 
 		EnchantmentItem* AddArmorEnchantment(BSTArray<Effect>& a_effects);
 		EnchantmentItem* AddWeaponEnchantment(BSTArray<Effect>& a_effects);
+		void             AddPotion(BSTSmartPointer<AlchemyItem, BSTCreatedObjectSmartPointerPolicy>& a_created, BSTArray<Effect>& a_effects);
 		void             DestroyEnchantment(EnchantmentItem* a_enchantment, bool a_isWeapon);
 		void             AddPotion(AlchemyItem*& a_created, const BSTArray<Effect>& a_effects);
 
@@ -42,4 +72,10 @@ namespace RE
 		mutable BSSpinLock                              lock;                // C8
 	};
 	static_assert(sizeof(BGSCreatedObjectManager) == 0xD0);
+
+	extern template struct BGSCreatedObjectManager::BSTCreatedObjectSmartPointerPolicy<AlchemyItem>;
+	extern template struct BGSCreatedObjectManager::BSTCreatedObjectSmartPointerPolicy<TESForm>;
+
+	template <class T>
+	using CreatedObjPtr = BSTSmartPointer<T, BGSCreatedObjectManager::BSTCreatedObjectSmartPointerPolicy>;
 }

--- a/src/RE/B/BGSCreatedObjectManager.cpp
+++ b/src/RE/B/BGSCreatedObjectManager.cpp
@@ -28,11 +28,28 @@ namespace RE
 		static REL::Relocation<func_t> func{ RELOCATION_ID(35267, 36169) };
 		return func(this, a_enchantment, a_isWeapon);
 	}
-	
-	void BGSCreatedObjectManager::AddPotion(AlchemyItem*& a_created, const BSTArray<Effect>& a_effects)
+
+	void BGSCreatedObjectManager::AddPotion(BSTSmartPointer<
+												AlchemyItem, 
+												BSTCreatedObjectSmartPointerPolicy>& a_created,
+											BSTArray<Effect>& a_effects)
 	{
 		using func_t = decltype(&BGSCreatedObjectManager::AddPotion);
 		static REL::Relocation<func_t> func{ RELOCATION_ID(35265, 36167) };
 		func(this, a_created, a_effects);
+	}
+
+	void BGSCreatedObjectManager::DecrementRef(AlchemyItem* a_alchItem)
+	{
+		using func_t = decltype(&BGSCreatedObjectManager::DecrementRef);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(0, 36171) };
+		return func(this, a_alchItem);
+	}
+
+	void BGSCreatedObjectManager::IncrementRef(AlchemyItem* a_alchItem)
+	{
+		using func_t = decltype(&BGSCreatedObjectManager::IncrementRef);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(0, 36170) };
+		return func(this, a_alchItem);
 	}
 }

--- a/src/RE/B/BGSCreatedObjectManager.cpp
+++ b/src/RE/B/BGSCreatedObjectManager.cpp
@@ -28,4 +28,11 @@ namespace RE
 		static REL::Relocation<func_t> func{ RELOCATION_ID(35267, 36169) };
 		return func(this, a_enchantment, a_isWeapon);
 	}
+	
+	void BGSCreatedObjectManager::AddPotion(AlchemyItem*& a_created, const BSTArray<Effect>& a_effects)
+	{
+		using func_t = decltype(&BGSCreatedObjectManager::AddPotion);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(35265, 36167) };
+		func(this, a_created, a_effects);
+	}
 }


### PR DESCRIPTION
Usage:
```cpp
RE::BSTArray<RE::Effect> effects;
RE::CreatedObjectPtr<RE::AlchemyItem> out;

auto* com = RE::BGSCreatedObjectManager::GetSingleton();
com->AddPotion(out, effects);

// Important: Increment refs by 1 for each item created (see `51354` + `0x2EC` in 1.6)
for (int i = 0; i < 20; ++i) { 
  com->IncrementRef(com.get());
}
RE::PlayerCharacter::GetSingleton()->AddObjectToContainer(out.get(), nullptr, 20, nullptr);
```