### PR TITLE
fix: 1.5 guards in `API.h`, `Interfaces.cpp/h`

### DIFF
--- a/include/SKSE/API.h
+++ b/include/SKSE/API.h
@@ -14,7 +14,12 @@ namespace SKSE
 {
 	struct InitInfo
 	{
+#ifdef SKYRIM_SUPPORT_AE
 		bool log{ true };
+#else
+		bool log{ false };
+#endif
+
 #ifndef NDEBUG
 		REX::ELogLevel logLevel{ REX::ELogLevel::Debug };
 #else

--- a/include/SKSE/Interfaces.h
+++ b/include/SKSE/Interfaces.h
@@ -507,6 +507,7 @@ namespace SKSE
 		[[nodiscard]] void*         AllocateFromLocalPool(std::size_t a_size) const;
 	};
 
+#ifdef SKYRIM_SUPPORT_AE
 	struct PluginVersionData
 	{
 	public:
@@ -593,12 +594,16 @@ namespace SKSE
 	static_assert(offsetof(PluginVersionData, compatibleVersions) == 0x30C);
 	static_assert(offsetof(PluginVersionData, xseMinimum) == 0x34C);
 	static_assert(sizeof(PluginVersionData) == 0x350);
+#endif
 }
 
 #define SKSE_EXPORT extern "C" [[maybe_unused]] __declspec(dllexport)
 #define SKSE_PLUGIN_LOAD(...) SKSE_EXPORT bool SKSEPlugin_Load(__VA_ARGS__)
 #define SKSE_PLUGIN_QUERY(...) SKSE_EXPORT bool SKSEPlugin_Query(__VA_ARGS__)
-#define SKSE_PLUGIN_VERSION SKSE_EXPORT constinit SKSE::PluginVersionData SKSEPlugin_Version
 #define SKSEPluginLoad SKSE_PLUGIN_LOAD
 #define SKSEPluginQuery SKSE_PLUGIN_QUERY
-#define SKSEPluginVersion SKSE_PLUGIN_VERSION
+
+#ifdef SKYRIM_SUPPORT_AE
+#	define SKSE_PLUGIN_VERSION SKSE_EXPORT constinit SKSE::PluginVersionData SKSEPlugin_Version
+#	define SKSEPluginVersion SKSE_PLUGIN_VERSION
+#endif

--- a/src/SKSE/API.cpp
+++ b/src/SKSE/API.cpp
@@ -121,7 +121,9 @@ namespace SKSE
 					spdlog::set_default_logger(std::move(logger));
 					spdlog::set_pattern(info.logPattern ? info.logPattern : "[%T.%e] [%=5t] [%L] %v");
 
+#ifdef SKYRIM_SUPPORT_AE
 					REX::INFO("{} v{}", GetPluginName(), GetPluginVersion());
+#endif
 				});
 			}
 		}

--- a/src/SKSE/Interfaces.cpp
+++ b/src/SKSE/Interfaces.cpp
@@ -144,8 +144,10 @@ namespace SKSE
 		return GetProxy().AllocateFromLocalPool(GetPluginHandle(), a_size);
 	}
 
+#ifdef SKYRIM_SUPPORT_AE
 	const PluginVersionData* PluginVersionData::GetSingleton() noexcept
 	{
 		return reinterpret_cast<const PluginVersionData*>(REX::W32::GetProcAddress(REX::W32::GetCurrentModule(), "SKSEPlugin_Version"));
 	}
+#endif
 }


### PR DESCRIPTION
disables `PluginVersionData` struct, defaults log init off