### PR TITLE
fix: Sky->IsRaining and sky->IsSnowing

### DIFF
--- a/src/RE/S/Sky.cpp
+++ b/src/RE/S/Sky.cpp
@@ -105,14 +105,38 @@ namespace RE
 
 	bool Sky::IsRaining() const
 	{
-		return (currentWeather && currentWeather->data.flags.any(TESWeather::WeatherDataFlag::kRainy) && (currentWeather->data.precipitationBeginFadeIn * (1.0f / 255.0f) < currentWeatherPct)) ||
-		       (lastWeather && lastWeather->data.flags.any(TESWeather::WeatherDataFlag::kRainy) && (lastWeather->data.precipitationEndFadeOut * (1.0f / 255.0f) + 0.001f > currentWeatherPct));
+		const bool currentIsRainy = currentWeather && currentWeather->data.flags.any(TESWeather::WeatherDataFlag::kRainy);
+		// precipitationBeginFadeIn is negative
+		const float currentFadeInPct = currentIsRainy ? 
+										(1.0f + static_cast<float>(currentWeather->data.precipitationBeginFadeIn) / 255.0f) : 
+										0.0f;
+		const bool currentlyRaining = currentIsRainy && currentFadeInPct < currentWeatherPct;
+
+		const bool lastWasRainy = lastWeather && lastWeather->data.flags.any(TESWeather::WeatherDataFlag::kRainy);
+		const float endFadeOutPtc = lastWasRainy ? 
+									static_cast<float>(lastWeather->data.precipitationEndFadeOut) / 255.0f : 
+									0.0f;
+		const bool isStillRaining = lastWasRainy && endFadeOutPtc > currentWeatherPct;
+
+		return currentlyRaining || isStillRaining;
 	}
 
 	bool Sky::IsSnowing() const
 	{
-		return (currentWeather && currentWeather->data.flags.any(TESWeather::WeatherDataFlag::kSnow) && (currentWeather->data.precipitationBeginFadeIn * (1.0f / 255.0f) < currentWeatherPct)) ||
-		       (lastWeather && lastWeather->data.flags.any(TESWeather::WeatherDataFlag::kSnow) && (lastWeather->data.precipitationEndFadeOut * (1.0f / 255.0f) + 0.001f > currentWeatherPct));
+		const bool currentIsSnowy = currentWeather && currentWeather->data.flags.any(TESWeather::WeatherDataFlag::kSnow);
+		// precipitationBeginFadeIn is negative
+		const float currentFadeInPct = currentIsSnowy ? 
+										(1.0f + static_cast<float>(currentWeather->data.precipitationBeginFadeIn) / 255.0f) : 
+										0.0f;
+		const bool currentlyRaining = currentIsSnowy && currentFadeInPct < currentWeatherPct;
+
+		const bool lastWasSnowy = lastWeather && lastWeather->data.flags.any(TESWeather::WeatherDataFlag::kSnow);
+		const float endFadeOutPtc = lastWasSnowy ? 
+									static_cast<float>(lastWeather->data.precipitationEndFadeOut) / 255.0f : 
+									0.0f;
+		const bool isStillRaining = lastWasSnowy && endFadeOutPtc > currentWeatherPct;
+
+		return currentlyRaining || isStillRaining;
 	}
 
 	void Sky::ReleaseWeatherOverride()


### PR DESCRIPTION
For `TESWeather`, `precipitationBeginFadeIn ` is negative. This means `IsRaining()` and `IsSnowing()` always return true if the current weather is Rainy/Snowy, regardless of fade in percent. Additionally, a small hysterisis may be in order - +/-0.05 is fine - but outside of the scope of the PR.